### PR TITLE
[VOS-062][Green] feat: Backend multi-model router — RAG-aware Ollama proxy

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,6 +10,10 @@ SUPABASE_JWT_SECRET=your_supabase_jwt_secret_here
 QWEN_ENDPOINT_URL=https://your-qwen-vllm-service.run.app/v1
 QWEN_MODEL_NAME=Qwen/Qwen3.5-9B-Instruct
 
+# ----- Home PC Ollama (optional) -----
+OLLAMA_ENDPOINT_URL=  # optional: http://YOUR_HOME_PC_IP:11434 or Tailscale IP
+OLLAMA_MODEL_NAME=qwen2.5:7b
+
 # ----- Gmail OAuth -----
 GMAIL_CLIENT_ID=your-gmail-oauth-client-id
 GMAIL_CLIENT_SECRET=your-gmail-oauth-client-secret

--- a/backend/app/api/v1/endpoints.py
+++ b/backend/app/api/v1/endpoints.py
@@ -3,13 +3,14 @@ import time
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Depends
-from typing import Optional, List
+from typing import Literal, Optional, List
 from pydantic import BaseModel
 from app.services.email_service import EmailService
 from app.services.feed_service import FeedService
 from app.services.health_service import HealthService
 from app.services.rag_service import RAGService
 from app.services.task_service import TaskService
+from app.services.ai_service import call_ollama
 from app.utils.auth import get_current_user
 import httpx
 import os
@@ -29,6 +30,8 @@ class EmailSendRequest(BaseModel):
 
 class ChatRequest(BaseModel):
     message: str
+    model_target: Optional[Literal['cloud', 'home_pc', 'device']] = 'cloud'
+    ollama_url: Optional[str] = None
 
 class HealthSyncPayload(BaseModel):
     heart_rate: Optional[float] = None
@@ -184,7 +187,27 @@ async def chat_with_ai(request: ChatRequest, user_id: str = Depends(get_current_
     # 1. Build RAG Context
     context = await rag_service.build_context_block(user_id, request.message)
 
-    # 2. Get Qwen Endpoint
+    # 2. Route to home_pc or reject device
+    if request.model_target == 'device':
+        raise HTTPException(
+            status_code=400,
+            detail="device model_target is local-only — do not route through backend",
+        )
+
+    if request.model_target == 'home_pc':
+        ollama_url = request.ollama_url or os.environ.get("OLLAMA_ENDPOINT_URL")
+        if not ollama_url:
+            raise HTTPException(
+                status_code=400,
+                detail="home_pc model_target requires ollama_url in request body or OLLAMA_ENDPOINT_URL env var",
+            )
+        try:
+            text = await call_ollama(request.message, context, ollama_url)
+        except httpx.HTTPError as e:
+            raise HTTPException(status_code=502, detail=f"Ollama unreachable: {e}")
+        return {"response": text, "model": "ollama/home_pc"}
+
+    # 3. Cloud path (unchanged) — get Qwen endpoint
     qwen_url = os.environ.get("QWEN_ENDPOINT_URL")
     if not qwen_url:
         return {"response": f"[MOCK CONTEXT]: {context}\n\n[REPLY]: I am functioning in mock mode because QWEN_ENDPOINT_URL is missing."}

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,2 +1,32 @@
 # VibeOS — AI Service
 # Qwen3.5-9B-Instruct inference via vLLM OpenAI-compatible API
+
+import os
+import httpx
+from typing import Optional
+
+
+async def call_ollama(message: str, rag_context: str, ollama_url: str) -> str:
+    """Proxy chat request to a user's Ollama instance with RAG context."""
+    base = ollama_url.rstrip('/')
+    system_prompt = (
+        "You are VibeOS Assistant. Use the following context to answer the user's question.\n\n"
+        f"Context:\n{rag_context}"
+        if rag_context
+        else "You are VibeOS Assistant."
+    )
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{base}/v1/chat/completions",
+            json={
+                "model": os.environ.get("OLLAMA_MODEL_NAME", "qwen2.5:7b"),
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": message},
+                ],
+                "stream": False,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        return response.json()["choices"][0]["message"]["content"]

--- a/backend/app/utils/config.py
+++ b/backend/app/utils/config.py
@@ -11,6 +11,8 @@ class Settings(BaseSettings):
     supabase_jwt_secret: str = ""
     qwen_endpoint_url: str = ""
     qwen_model_name: str = "Qwen/Qwen3.5-9B-Instruct"
+    ollama_endpoint_url: str = ""
+    ollama_model_name: str = "qwen2.5:7b"
     cors_origins: str = ""
     gmail_client_id: str = ""
     gmail_client_secret: str = ""


### PR DESCRIPTION
## Summary
- Adds `model_target` (Optional, defaults to `'cloud'`) and `ollama_url` fields to `ChatRequest`
- Routes `home_pc` requests to new `call_ollama()` function in `ai_service.py` with full RAG context injected into system prompt
- Returns HTTP 400 for `device` target (local-only — never routes through backend)
- Returns HTTP 400 if `ollama_url` missing for `home_pc` target; HTTP 502 if Ollama unreachable
- `OLLAMA_MODEL_NAME` env var used — model name not hardcoded
- `OLLAMA_ENDPOINT_URL` and `OLLAMA_MODEL_NAME` added to `config.py` and `.env.example`
- Cloud path completely unchanged — zero regression

## Test plan
- [ ] `POST /chat` with no `model_target` → cloud response (regression check)
- [ ] `POST /chat` with `model_target: "cloud"` → cloud response
- [ ] `POST /chat` with `model_target: "home_pc"` + valid `ollama_url` → Ollama response with RAG context
- [ ] `POST /chat` with `model_target: "home_pc"` + no URL → HTTP 400
- [ ] `POST /chat` with `model_target: "home_pc"` + unreachable URL → HTTP 502
- [ ] `POST /chat` with `model_target: "device"` → HTTP 400