### PR TITLE
[VOS-063][Pink] CRITICAL: Fix feeds empty + strip Qwen think tags

### DIFF
--- a/backend/app/api/v1/endpoints.py
+++ b/backend/app/api/v1/endpoints.py
@@ -250,6 +250,10 @@ async def chat_with_ai(request: ChatRequest, user_id: str = Depends(get_current_
                 data = ai_response.json()
                 ai_content = data["choices"][0]["message"]["content"]
 
+                # Strip Qwen chain-of-thought <think>...</think> blocks
+                import re as _re
+                ai_content = _re.sub(r'<think>.*?</think>', '', ai_content, flags=_re.DOTALL).strip()
+
                 # Store both user message and AI response in chat_history
                 try:
                     now = datetime.now(timezone.utc).isoformat()

--- a/mobile/src/screens/FeedsScreen.jsx
+++ b/mobile/src/screens/FeedsScreen.jsx
@@ -21,8 +21,8 @@ export default function FeedsScreen() {
         fetchTechFeeds().catch(() => []),
         fetchConcerts().catch(() => []),
       ]);
-      setTechArticles(Array.isArray(techData) ? techData : []);
-      setConcerts(Array.isArray(concertData) ? concertData : []);
+      setTechArticles(Array.isArray(techData?.articles) ? techData.articles : []);
+      setConcerts(Array.isArray(concertData?.concerts) ? concertData.concerts : []);
     } finally {
       setLoading(false);
       setRefreshing(false);


### PR DESCRIPTION
## Fixes
**Feeds empty (both tabs):** `fetchTechFeeds()` returns `{articles:[...]}` — FeedsScreen was doing `Array.isArray(techData)` on the object wrapper → always false → set `[]`. Both Tech and Concerts tabs showed empty despite backend returning full data. Fix: unwrap `techData.articles` and `concertData.concerts`.

**`<think>` tags in chat:** Qwen model outputs chain-of-thought `<think>...</think>` blocks. Backend was returning raw `ai_content` including these markers, visible in the UI. Fix: strip with regex before returning response.

Verified: backend `/feeds/tech` and `/feeds/concerts` both return data correctly. Mobile was silently discarding it.