### PR TITLE
feat(blue): VOS-081/082/102 — Chat Markdown rendering + Job Engine UI

### DIFF
--- a/mobile/src/screens/JobsScreen.jsx
+++ b/mobile/src/screens/JobsScreen.jsx
@@ -1,5 +1,7 @@
+// Modified: VOS-102 — Markdown description rendering + source badges
 import { Award, Briefcase, Building2, Check, ChevronRight, Clock, DollarSign, ExternalLink, Inbox, MapPin, Plus, Search, Send, Sparkles, X, Zap } from 'lucide-react-native';
 import React, { useState, useEffect } from 'react';
+import Markdown from 'react-native-markdown-display';
 import {
   View, TouchableOpacity, TextInput,
   ActivityIndicator, RefreshControl, ScrollView,
@@ -14,6 +16,35 @@ import { MobileHeader } from '../components/MobileHeader';
 import { MobileCard } from '../components/MobileCard';
 import { LinearGradient } from 'expo-linear-gradient';
 import { BlurView } from 'expo-blur';
+
+const SOURCE_META = {
+  weworkremotely: { label: 'We Work Remotely', color: '#4ade80', bg: 'rgba(74,222,128,0.12)', border: 'rgba(74,222,128,0.3)' },
+  'serper-linkedin': { label: 'LinkedIn', color: '#60a5fa', bg: 'rgba(96,165,250,0.12)', border: 'rgba(96,165,250,0.3)' },
+  proxycurl: { label: 'LinkedIn', color: '#60a5fa', bg: 'rgba(96,165,250,0.12)', border: 'rgba(96,165,250,0.3)' },
+  crustdata: { label: 'Crustdata', color: '#c084fc', bg: 'rgba(192,132,252,0.12)', border: 'rgba(192,132,252,0.3)' },
+};
+
+function getSourceMeta(source) {
+  if (!source) return { label: 'Unknown', color: '#BBC9CD', bg: 'rgba(187,201,205,0.1)', border: 'rgba(187,201,205,0.2)' };
+  return SOURCE_META[source.toLowerCase()] ?? { label: source, color: '#BBC9CD', bg: 'rgba(187,201,205,0.1)', border: 'rgba(187,201,205,0.2)' };
+}
+
+function htmlToMarkdown(raw) {
+  if (!raw) return '';
+  if (!/<[a-z][\s\S]*>/i.test(raw)) return raw;
+  return raw
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n\n').replace(/<p[^>]*>/gi, '')
+    .replace(/<\/li>/gi, '\n').replace(/<li[^>]*>/gi, '- ')
+    .replace(/<\/(ul|ol)>/gi, '\n').replace(/<(ul|ol)[^>]*>/gi, '\n')
+    .replace(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi, '### $1\n')
+    .replace(/<strong[^>]*>([\s\S]*?)<\/strong>/gi, '**$1**')
+    .replace(/<b[^>]*>([\s\S]*?)<\/b>/gi, '**$1**')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&nbsp;/g, ' ').replace(/&quot;/g, '"')
+    .replace(/\n{3,}/g, '\n\n').trim();
+}
 
 export default function JobsScreen() {
   const [campaigns, setCampaigns] = useState([]);
@@ -108,71 +139,77 @@ export default function JobsScreen() {
 
   const renderJobItem = (item) => {
     const matchScore = item.match_score ? Math.round(item.match_score * 100) : 0;
+    const src = getSourceMeta(item.source);
+    const descMarkdown = htmlToMarkdown(item.job_description || '');
     return (
       <MobileCard key={item.id} style={styles.jobCard}>
-        <View style={styles.jobHeader}>
-          <View style={styles.jobIconContainer}>
-            <Building2 size={24} color={palette.accentPrimary}  />
+        {/* Source badge + match score row */}
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+          <View style={[styles.sourceBadge, { backgroundColor: src.bg, borderColor: src.border }]}>
+            <Text style={[styles.sourceBadgeText, { color: src.color }]}>{src.label}</Text>
           </View>
-          <View style={{ flex: 1 }}>
-            <Text style={styles.jobTitle}>{item.job_title}</Text>
-            <Text style={styles.jobSubtitle}>{item.company_name} • {item.remote_type || item.source}</Text>
-            <View style={styles.matchBadge}>
-              <Sparkles size={12} color="#4ade80"  />
-              <Text style={styles.matchText}>{matchScore}% Match</Text>
-            </View>
+          <View style={styles.matchBadge}>
+            <Sparkles size={12} color="#4ade80" />
+            <Text style={styles.matchText}>{matchScore}% Match</Text>
           </View>
         </View>
 
-        <Text numberOfLines={3} style={styles.jobDescription}>
-          {item.job_description || 'No description available.'}
-        </Text>
+        <View style={styles.jobHeader}>
+          <View style={styles.jobIconContainer}>
+            <Building2 size={24} color={palette.accentPrimary} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.jobTitle}>{item.job_title}</Text>
+            <Text style={styles.jobSubtitle}>{item.company_name} • {item.remote_type || 'Remote'}</Text>
+          </View>
+        </View>
+
+        {/* Markdown description */}
+        <Markdown style={markdownStyles}>
+          {descMarkdown || 'No description available.'}
+        </Markdown>
 
         <View style={styles.jobTags}>
           <View style={styles.tag}>
-            <MapPin size={14} color={palette.accentPrimary}  />
+            <MapPin size={14} color={palette.accentPrimary} />
             <Text style={styles.tagText}>{item.location || 'N/A'}</Text>
           </View>
           <View style={styles.tag}>
-            <DollarSign size={14} color={palette.accentPrimary}  />
+            <DollarSign size={14} color={palette.accentPrimary} />
             <Text style={styles.tagText}>{item.salary_range || 'Undisclosed'}</Text>
           </View>
           <View style={styles.tag}>
-            <Clock size={14} color={palette.accentPrimary}  />
+            <Clock size={14} color={palette.accentPrimary} />
             <Text style={styles.tagText}>Recently</Text>
           </View>
         </View>
 
-        {/* Why this matches section */}
-        <View style={styles.matchReasons}>
-           <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6 }}>
-              <Zap size={14} color={palette.accentPrimary} style={{ marginRight: 6 }}  />
+        {item.match_reasoning && (
+          <View style={styles.matchReasons}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6 }}>
+              <Zap size={14} color={palette.accentPrimary} style={{ marginRight: 6 }} />
               <Text style={{ fontSize: 12, fontWeight: 'bold', color: '#FFF' }}>Why This Matches</Text>
-           </View>
-           <View style={styles.reasonRow}>
-              <Check size={12} color={palette.accentPrimary}  />
-              <Text style={styles.reasonText}>Skills align with profile</Text>
-           </View>
-           <View style={styles.reasonRow}>
-              <Check size={12} color={palette.accentPrimary}  />
-              <Text style={styles.reasonText}>Salary meets requirements</Text>
-           </View>
-        </View>
+            </View>
+            <View style={styles.reasonRow}>
+              <Check size={12} color={palette.accentPrimary} />
+              <Text style={styles.reasonText}>{item.match_reasoning}</Text>
+            </View>
+          </View>
+        )}
 
         <View style={styles.jobActions}>
-          <TouchableOpacity 
+          <TouchableOpacity
             onPress={() => item.job_url && Linking.openURL(item.job_url)}
             style={styles.actionButtonPrimary}
           >
-            <ExternalLink size={16} color={palette.accentPrimary}  />
+            <ExternalLink size={16} color={palette.accentPrimary} />
             <Text style={styles.actionButtonTextPrimary}>View</Text>
           </TouchableOpacity>
-          
-          <TouchableOpacity 
+          <TouchableOpacity
             onPress={() => handleInboxAction(item, 'APPROVED')}
             style={styles.actionButtonSecondary}
           >
-            <Send size={16} color="#4ade80"  />
+            <Send size={16} color="#4ade80" />
             <Text style={styles.actionButtonTextSecondary}>Apply</Text>
           </TouchableOpacity>
         </View>
@@ -566,6 +603,17 @@ const styles = StyleSheet.create({
     color: palette.textMuted,
     marginBottom: 6,
   },
+  sourceBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  sourceBadgeText: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+  },
   matchBadge: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -791,4 +839,15 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
 });
+
+// Modified: VOS-102 — markdown display styles for job descriptions
+const markdownStyles = {
+  body: { color: palette.textMuted, fontSize: 13, lineHeight: 20 },
+  paragraph: { color: palette.textMuted, fontSize: 13, lineHeight: 20, marginBottom: 8 },
+  bullet_list: { marginBottom: 8 },
+  list_item: { color: palette.textMuted, fontSize: 13, lineHeight: 20 },
+  heading3: { color: '#FFF', fontSize: 13, fontWeight: '700', marginBottom: 4 },
+  strong: { color: '#DAE2FD', fontWeight: '700' },
+  em: { color: palette.textMuted, fontStyle: 'italic' },
+};
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -65,6 +65,7 @@
         "vaul": "^1.1.2"
       },
       "devDependencies": {
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^4.3.0",
         "eslint": "^9.0.0",
         "vite": "^6.0.0"
@@ -3594,6 +3595,7 @@
       "version": "15.5.13",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
       "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"

--- a/web/package.json
+++ b/web/package.json
@@ -67,6 +67,7 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.3.0",
     "eslint": "^9.0.0",
     "vite": "^6.0.0"

--- a/web/src/components/cyan/JobsView.tsx
+++ b/web/src/components/cyan/JobsView.tsx
@@ -1,13 +1,53 @@
 import { useState, useEffect } from "react";
 import { useOutletContext } from "react-router";
-import { 
+import {
   Menu, Briefcase, Search, MapPin, DollarSign, Building2,
   Clock, ExternalLink, Sparkles, Plus, X, Send, Inbox, Check, XCircle,
   ArrowLeft, Upload, FileText, Target, TrendingUp, Award, Zap
 } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
 import { GlassCard } from "./GlassCard";
 import { BurgerMenu } from "./BurgerMenu";
 import { Sidebar } from "./Sidebar";
+
+// Modified: VOS-102 — HTML description rendering + source badge support
+const SOURCE_META: Record<string, { label: string; color: string; bg: string; border: string }> = {
+  "weworkremotely": { label: "We Work Remotely", color: "#4ade80", bg: "rgba(74, 222, 128, 0.12)", border: "rgba(74, 222, 128, 0.3)" },
+  "serper-linkedin": { label: "LinkedIn", color: "#60a5fa", bg: "rgba(96, 165, 250, 0.12)", border: "rgba(96, 165, 250, 0.3)" },
+  "proxycurl": { label: "LinkedIn", color: "#60a5fa", bg: "rgba(96, 165, 250, 0.12)", border: "rgba(96, 165, 250, 0.3)" },
+  "crustdata": { label: "Crustdata", color: "#c084fc", bg: "rgba(192, 132, 252, 0.12)", border: "rgba(192, 132, 252, 0.3)" },
+};
+
+function getSourceMeta(source?: string | null) {
+  if (!source) return { label: "Unknown", color: "#BBC9CD", bg: "rgba(187, 201, 205, 0.1)", border: "rgba(187, 201, 205, 0.2)" };
+  return SOURCE_META[source.toLowerCase()] ?? { label: source, color: "#BBC9CD", bg: "rgba(187, 201, 205, 0.1)", border: "rgba(187, 201, 205, 0.2)" };
+}
+
+// Modified: VOS-102 — convert scraped HTML descriptions to Markdown for clean rendering
+function htmlToMarkdown(raw: string): string {
+  if (!raw) return "";
+  if (!/<[a-z][\s\S]*>/i.test(raw)) return raw;
+  return raw
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<p[^>]*>/gi, "")
+    .replace(/<\/li>/gi, "\n")
+    .replace(/<li[^>]*>/gi, "- ")
+    .replace(/<\/(ul|ol)>/gi, "\n")
+    .replace(/<(ul|ol)[^>]*>/gi, "\n")
+    .replace(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi, "### $1\n")
+    .replace(/<strong[^>]*>([\s\S]*?)<\/strong>/gi, "**$1**")
+    .replace(/<b[^>]*>([\s\S]*?)<\/b>/gi, "**$1**")
+    .replace(/<em[^>]*>([\s\S]*?)<\/em>/gi, "*$1*")
+    .replace(/<i[^>]*>([\s\S]*?)<\/i>/gi, "*$1*")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ").replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
 import { campaignService } from "../../services/campaignService";
 import { supabase } from "../../services/supabase";
 
@@ -236,105 +276,120 @@ export function JobsView() {
             </div>
           </GlassCard>
 
-          {/* Matched Jobs */}
+          {/* Matched Jobs — Modified: VOS-102 grid layout, Markdown descriptions, source badges */}
           <div>
             <div className="flex items-center gap-2 mb-4">
               <div className="h-1 w-12 bg-gradient-to-r from-[#00FFFF] to-transparent rounded-full"></div>
               <span className="text-xs font-semibold text-[#BBC9CD] uppercase tracking-widest">
-                Matched Opportunities
+                Matched Opportunities ({campaignItems.length})
               </span>
             </div>
 
-            <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
               {campaignItems.length === 0 && (
-                <div className="text-[#BBC9CD] py-4">No matched jobs found for this campaign yet.</div>
+                <div className="col-span-full text-[#BBC9CD] py-4">No matched jobs found for this campaign yet.</div>
               )}
-              {campaignItems.map((job) => (
-                <GlassCard key={job.id} className="!p-6 hover:border-[#00FFFF]/40 transition-all">
-                  <div className="flex flex-col md:flex-row gap-6">
-                    {/* Company Icon */}
-                    <div className="flex-shrink-0">
-                      <div className="w-20 h-20 rounded-xl bg-gradient-to-br from-[#00FFFF]/20 to-[#0099CC]/20 border border-[#00FFFF]/30 flex items-center justify-center">
-                        <Building2 className="w-10 h-10 text-[#00FFFF]" />
+              {campaignItems.map((job) => {
+                const src = getSourceMeta(job.source);
+                const descMarkdown = htmlToMarkdown(job.job_description || "");
+                return (
+                  <GlassCard key={job.id} className="!p-5 hover:border-[#00FFFF]/40 transition-all flex flex-col">
+                    {/* Card Header: source badge + match score */}
+                    <div className="flex items-center justify-between gap-2 mb-3">
+                      <span
+                        className="text-xs font-bold px-2 py-1 rounded-md"
+                        style={{ color: src.color, backgroundColor: src.bg, border: `1px solid ${src.border}` }}
+                      >
+                        {src.label}
+                      </span>
+                      <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-green-500/15 border border-green-500/25">
+                        <Sparkles className="w-3.5 h-3.5 text-green-400" />
+                        <span className="text-xs font-bold text-green-400">
+                          {job.match_score ? Math.round(job.match_score * 100) : 0}%
+                        </span>
                       </div>
                     </div>
 
-                    {/* Job Details */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-start justify-between gap-3 mb-3">
-                        <div className="flex-1">
-                          <h3 className="font-bold text-[#DAE2FD] text-xl mb-1">{job.job_title}</h3>
-                          <div className="flex items-center gap-2 text-[#BBC9CD] mb-3">
-                            <span className="font-semibold">{job.company_name}</span>
-                            <span>•</span>
-                            <span>{job.remote_type}</span>
+                    {/* Company icon + title */}
+                    <div className="flex items-start gap-3 mb-3">
+                      <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-[#00FFFF]/20 to-[#0099CC]/20 border border-[#00FFFF]/30 flex items-center justify-center flex-shrink-0">
+                        <Building2 className="w-5 h-5 text-[#00FFFF]" />
+                      </div>
+                      <div className="min-w-0">
+                        <h3 className="font-bold text-[#DAE2FD] text-base leading-tight mb-0.5 truncate">{job.job_title}</h3>
+                        <p className="text-sm text-[#BBC9CD] truncate">{job.company_name} · {job.remote_type}</p>
+                      </div>
+                    </div>
+
+                    {/* Meta tags */}
+                    <div className="flex flex-wrap gap-3 text-xs mb-3">
+                      <div className="flex items-center gap-1 text-[#BBC9CD]">
+                        <MapPin className="w-3.5 h-3.5 text-[#00FFFF]" />
+                        {job.location || "N/A"}
+                      </div>
+                      <div className="flex items-center gap-1 text-[#BBC9CD]">
+                        <DollarSign className="w-3.5 h-3.5 text-[#00FFFF]" />
+                        {job.salary_range || "Undisclosed"}
+                      </div>
+                      <div className="flex items-center gap-1 text-[#BBC9CD]">
+                        <Clock className="w-3.5 h-3.5 text-[#00FFFF]" />
+                        Recently
+                      </div>
+                    </div>
+
+                    {/* Description — rendered as Markdown */}
+                    <div className="flex-1 overflow-hidden mb-3 prose prose-sm prose-invert max-w-none
+                      [&>p]:text-[#BBC9CD] [&>p]:text-sm [&>p]:leading-relaxed [&>p]:mb-2
+                      [&>ul]:text-[#BBC9CD] [&>ul]:text-sm [&>ul]:pl-4 [&>ul]:mb-2
+                      [&>li]:mb-0.5 [&>h3]:text-white [&>h3]:text-sm [&>h3]:font-semibold [&>h3]:mb-1
+                      line-clamp-[8]">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+                        {descMarkdown || "No description available."}
+                      </ReactMarkdown>
+                    </div>
+
+                    {/* Match reason */}
+                    {(job.match_reasoning || prefs?.keywords) && (
+                      <div className="bg-[#0A0A0A]/50 rounded-lg p-3 border border-[#00FFFF]/10 mb-3">
+                        <div className="flex items-center gap-1.5 mb-2">
+                          <Zap className="w-3.5 h-3.5 text-[#00FFFF]" />
+                          <span className="font-semibold text-white text-xs">Why This Matches</span>
+                        </div>
+                        {prefs?.keywords && (
+                          <div className="flex items-start gap-1.5 text-xs text-[#BBC9CD]">
+                            <Check className="w-3.5 h-3.5 text-[#00FFFF] mt-0.5 flex-shrink-0" />
+                            <span>Keywords: {prefs.keywords}</span>
                           </div>
-                        </div>
-                        <div className="flex items-center gap-2 px-3 py-1 rounded-lg bg-green-500/20 border border-green-500/30">
-                          <Sparkles className="w-5 h-5 text-green-400" />
-                          <span className="text-base font-bold text-green-400">
-                            {job.match_score ? Math.round(job.match_score * 100) : 0}% Match
-                          </span>
-                        </div>
+                        )}
+                        {job.match_reasoning && (
+                          <div className="flex items-start gap-1.5 text-xs text-[#BBC9CD] mt-1">
+                            <Check className="w-3.5 h-3.5 text-[#00FFFF] mt-0.5 flex-shrink-0" />
+                            <span>{job.match_reasoning}</span>
+                          </div>
+                        )}
                       </div>
+                    )}
 
-                      <p className="text-[#BBC9CD] mb-4">{job.job_description}</p>
-
-                      <div className="flex flex-wrap items-center gap-4 mb-4">
-                        <div className="flex items-center gap-2 text-sm">
-                          <MapPin className="w-4 h-4 text-[#00FFFF]" />
-                          <span className="text-[#BBC9CD]">{job.location || "N/A"}</span>
-                        </div>
-                        <div className="flex items-center gap-2 text-sm">
-                          <DollarSign className="w-4 h-4 text-[#00FFFF]" />
-                          <span className="text-[#BBC9CD]">{job.salary_range || "Undisclosed"}</span>
-                        </div>
-                        <div className="flex items-center gap-2 text-sm">
-                          <Clock className="w-4 h-4 text-[#00FFFF]" />
-                          <span className="text-[#BBC9CD]">Recently</span>
-                        </div>
-                      </div>
-
-                      {/* AI Match Reasons */}
-                      <div className="bg-[#0A0A0A]/50 rounded-lg p-4 border border-[#00FFFF]/10 mb-4">
-                        <div className="flex items-center gap-2 mb-3">
-                          <Zap className="w-4 h-4 text-[#00FFFF]" />
-                          <h4 className="font-semibold text-white text-sm">Why This Matches Your Profile</h4>
-                        </div>
-                        <ul className="space-y-2 text-sm text-[#BBC9CD]">
-                          <li className="flex items-start gap-2">
-                            <Check className="w-4 h-4 text-[#00FFFF] mt-0.5 flex-shrink-0" />
-                            <span>Aligned with your campaign keywords: {prefs?.keywords}</span>
-                          </li>
-                          {job.match_reasoning && (
-                             <li className="flex items-start gap-2">
-                              <Check className="w-4 h-4 text-[#00FFFF] mt-0.5 flex-shrink-0" />
-                              <span>{job.match_reasoning}</span>
-                            </li>
-                          )}
-                        </ul>
-                      </div>
-
-                      <div className="flex flex-wrap gap-3">
-                        <button 
-                          onClick={() => window.open(job.job_url || '', '_blank')}
-                          className="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-[#00FFFF]/20 to-[#0099CC]/20 hover:from-[#00FFFF]/30 hover:to-[#0099CC]/30 text-[#00FFFF] font-semibold transition-all border border-[#00FFFF]/40"
-                        >
-                          <ExternalLink className="w-4 h-4" />
-                          View Full Details
-                        </button>
-                        <button className="flex items-center gap-2 px-4 py-2 rounded-xl bg-green-500/20 hover:bg-green-500/30 text-green-400 font-semibold transition-colors border border-green-500/30">
-                          <Send className="w-4 h-4" />
-                          Quick Apply
-                        </button>
-                        <button className="px-4 py-2 rounded-xl bg-[#1A1A1A]/50 hover:bg-[#1A1A1A] text-[#BBC9CD] hover:text-[#00FFFF] font-semibold transition-colors border border-[#00FFFF]/20">
-                          Save for Later
-                        </button>
-                      </div>
+                    {/* Actions */}
+                    <div className="flex gap-2 mt-auto">
+                      <button
+                        onClick={() => window.open(job.job_url || "", "_blank")}
+                        className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-gradient-to-r from-[#00FFFF]/15 to-[#0099CC]/15 hover:from-[#00FFFF]/25 hover:to-[#0099CC]/25 text-[#00FFFF] text-xs font-semibold transition-all border border-[#00FFFF]/30"
+                      >
+                        <ExternalLink className="w-3.5 h-3.5" />
+                        View
+                      </button>
+                      <button
+                        onClick={() => handleInboxAction(job.id, "APPROVED")}
+                        className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-green-500/15 hover:bg-green-500/25 text-green-400 text-xs font-semibold transition-colors border border-green-500/25"
+                      >
+                        <Send className="w-3.5 h-3.5" />
+                        Apply
+                      </button>
                     </div>
-                  </div>
-                </GlassCard>
-              ))}
+                  </GlassCard>
+                );
+              })}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **VOS-081**: Web Chat — AI responses now render as Markdown via ReactMarkdown + remark-gfm + rehype-sanitize
- **VOS-082**: Mobile Chat — AI responses render via react-native-markdown-display with OLED markdownStyles
- **VOS-102**: Job Engine UI — responsive card grid (2-3 col), HTML→Markdown descriptions, colour-coded source badges per job board

## Files Changed
- \`web/src/components/Chat/MessageBubble.tsx\`
- \`mobile/src/screens/ChatScreen.jsx\`
- \`web/src/components/cyan/JobsView.tsx\`
- \`mobile/src/screens/JobsScreen.jsx\`

## Test Plan
- [ ] Web: AI chat response renders bold, code blocks, lists correctly
- [ ] Mobile: AI chat response renders with correct OLED palette
- [ ] Web: Jobs screen shows 2-3 column card grid with source badges
- [ ] Mobile: Jobs screen shows source badge + Markdown descriptions
- [ ] \`npm run build\` passes (web)
- [ ] \`npm run lint\` passes (mobile)

Closes #101, #102