### PR TITLE
feat(jobs): replace keyword scoring with CV embedding cosine similarity

### DIFF
--- a/.claude/skills/supercyan-frontend/SKILL.md
+++ b/.claude/skills/supercyan-frontend/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: supercyan-frontend
+description: Use this skill when building any React component or UI feature for the SuperCyan web app (/web). Contains the exact OLED color palette, GlassCard usage, inline Tailwind hex patterns, section header conventions, button styles, and component structure. Any agent touching the frontend MUST use this skill to avoid introducing off-palette colours or inconsistent styling. Trigger on: "build a component", "add a section", "update the UI", "style", "add a view", anything involving web/src/components.
+---
+
+# SuperCyan Frontend Conventions
+
+The web app is a React + Vite app with an OLED-first dark theme. All styling is done with **inline Tailwind utility classes using explicit hex values** — no separate CSS files for components, no CSS variables in component files. The theme system in `theme.css` is only used for global resets; component colours are all hard-coded from the palette below.
+
+---
+
+## Colour Palette
+
+Always use these exact values — nothing else.
+
+| Token | Hex | Use |
+|-------|-----|-----|
+| Cyan accent | `#00FFFF` | Primary accent, borders, headers, active states |
+| Cyan dark | `#0099CC` | Gradient start, secondary accent |
+| Primary text | `#DAE2FD` | Body text, titles |
+| Muted text | `#BBC9CD` | Metadata, labels, inactive states |
+| Card background | `#1A1A1A` | Surface cards, list items |
+| Card dark | `#0D0D12` | Deeper card layer |
+| Page background | `#080808` | Page/view background |
+| Near-black | `#0D0D0D` | Input backgrounds, deepest layer |
+| Separator | `#2A2A2A` | Borders, dividers |
+
+**Urgency colours (task feature):**
+
+| Level | Border / Badge | Background tint |
+|-------|---------------|-----------------|
+| High | `#FF4444` | `rgba(255,68,68,0.12)` |
+| Medium | `#D97706` | `rgba(217,119,6,0.12)` |
+| Low | `#4499DD` | `rgba(68,153,221,0.12)` |
+| Overdue (always) | `#F59E0B` | `rgba(245,158,11,0.15)` |
+
+---
+
+## GlassCard
+
+Import from `@/components/common/GlassCard` (or the path used in the file you're editing — check existing imports). Use it as the top-level wrapper for any card or panel section.
+
+```tsx
+<GlassCard className="p-6">
+  {/* content */}
+</GlassCard>
+```
+
+It provides the frosted-glass background and rounded corners. Do not replicate its styles manually.
+
+---
+
+## Section Headers
+
+Every major section uses this pattern — a title with a cyan gradient underline:
+
+```tsx
+<div>
+  <h2 className="text-xl font-bold" style={{ color: '#DAE2FD' }}>Section Title</h2>
+  <div style={{ width: '60px', height: '2px', background: 'linear-gradient(to right, #00FFFF, transparent)', marginTop: '6px' }} />
+</div>
+```
+
+---
+
+## Stat Pills (compact metadata row)
+
+Used for counts and percentages in header rows:
+
+```tsx
+<div className="flex gap-2">
+  <div className="px-3 py-1 rounded-full text-xs" style={{ background: '#1A1A1A', color: '#BBC9CD' }}>
+    5 tasks
+  </div>
+  <div className="px-3 py-1 rounded-full text-xs" style={{ background: '#1A1A1A', color: '#00FFFF' }}>
+    2 done
+  </div>
+</div>
+```
+
+---
+
+## Buttons
+
+**Primary action (cyan gradient):**
+```tsx
+<button
+  className="w-full py-2.5 rounded-xl font-bold text-sm"
+  style={{ background: 'linear-gradient(135deg, #0099CC, #00FFFF)', color: '#000' }}
+>
+  Save
+</button>
+```
+
+**Secondary / ghost:**
+```tsx
+<button
+  className="px-3 py-1.5 rounded-lg text-xs"
+  style={{ background: '#0D0D0D', border: '1px solid #333', color: '#BBC9CD' }}
+>
+  Cancel
+</button>
+```
+
+**Destructive:**
+```tsx
+<button
+  className="px-4 py-2 rounded-xl font-semibold text-sm"
+  style={{ background: 'rgba(255,68,68,0.15)', border: '1px solid rgba(255,68,68,0.4)', color: '#FF4444' }}
+>
+  Delete
+</button>
+```
+
+---
+
+## Inputs
+
+```tsx
+<input
+  className="w-full px-3 py-2 rounded-lg text-sm outline-none"
+  style={{ background: '#0D0D0D', border: '1px solid #2A2A2A', color: '#DAE2FD' }}
+  placeholder="Type here..."
+/>
+```
+
+Focus ring: add `focus:border-[#00FFFF]` or handle with `onFocus`/`onBlur` state.
+
+---
+
+## List / Card Items
+
+Standard list item (e.g. task card, email row):
+
+```tsx
+<div
+  className="flex items-center gap-3 px-4 py-3 rounded-xl"
+  style={{ background: '#1A1A1A', borderLeft: '3px solid #00FFFF' }}
+>
+  {/* left border colour changes per urgency/state */}
+</div>
+```
+
+Completed / dimmed variant:
+```tsx
+style={{ background: '#0F0F0F', opacity: 0.5, borderLeft: '3px solid #333' }}
+```
+
+---
+
+## Progress Bar
+
+```tsx
+<div className="h-1 rounded-full overflow-hidden" style={{ background: '#1A1A1A' }}>
+  <div
+    className="h-full rounded-full transition-all duration-500"
+    style={{ width: `${pct}%`, background: 'linear-gradient(to right, #0099CC, #00FFFF)' }}
+  />
+</div>
+```
+
+---
+
+## Component File Structure
+
+New view components live in `web/src/components/cyan/`. New sub-components (reusable pieces used by one view) live alongside their parent or in `web/src/components/common/` if shared.
+
+Each new file:
+- Named `PascalCase.tsx`
+- Exports a single default component
+- Imports styles inline — no companion `.css` file
+- Uses the palette above — no new colours
+
+---
+
+## Dos and Don'ts
+
+**Do:**
+- Use inline `style={{}}` for colours — Tailwind's JIT won't pick up arbitrary hex values reliably
+- Keep components under ~300 lines; split if growing larger
+- Use `GlassCard` for panels, not bare `div` with manual background
+- Match existing icon library (check what's imported in nearby files — usually `lucide-react`)
+
+**Don't:**
+- Introduce new hex values not in the palette above
+- Create companion `.css` files for new components
+- Use Tailwind colour names (e.g. `bg-gray-800`) — always use explicit hex
+- Add `className` for colours — use `style={{}}` for the palette

--- a/.claude/skills/supercyan-task-feature/SKILL.md
+++ b/.claude/skills/supercyan-task-feature/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: supercyan-task-feature
+description: Use this skill when implementing any part of the Task Dashboard redesign for SuperCyan. Contains the approved spec decisions, urgency colour rules, overdue detection logic, voice-to-task flow, component interfaces, and backend schema changes. Trigger on: "task dashboard", "urgency", "overdue tasks", "voice input", "VoiceTaskInput", "parse-voice", "getOverdueTasks", or any work in TaskDashboard.tsx or taskService.ts.
+---
+
+# SuperCyan Task Feature — Implementation Reference
+
+Full spec: `docs/superpowers/specs/2026-03-23-task-dashboard-redesign.md`
+
+This skill gives you the key facts you need without reading the whole spec.
+
+---
+
+## Approved Decisions
+
+| # | Decision |
+|---|----------|
+| Urgency levels | 3: **high / medium / low** (lowercase in DB and code) |
+| Overdue style | Amber badge inline — same list, amber left border + "overdue" pill |
+| Architecture | Enhance `TaskDashboard` + new `VoiceTaskInput` component |
+| Voice confirm | Pre-fill form, user reviews and saves manually |
+| Next-day scheduling | Today / Tomorrow toggle (resolves to YYYY-MM-DD before `createTask()`) |
+
+---
+
+## Urgency Colours
+
+| Level | Left border | Badge text | Badge bg |
+|-------|------------|-----------|---------|
+| `high` | `#FF4444` | `#FF4444` | `rgba(255,68,68,0.12)` |
+| `medium` | `#D97706` | `#D97706` | `rgba(217,119,6,0.12)` |
+| `low` | `#4499DD` | `#4499DD` | `rgba(68,153,221,0.12)` |
+| overdue (any urgency) | `#F59E0B` | `#F59E0B` | `rgba(245,158,11,0.15)` |
+
+**Overdue border always overrides urgency border.** The urgency pill badge still shows inside the card.
+
+---
+
+## Task Type (updated)
+
+```typescript
+// web/src/types/tasks.ts — add urgency field
+export interface Task {
+  id: string;
+  user_id: string;
+  date: string;           // YYYY-MM-DD (PostgreSQL DATE, compared as string)
+  title: string;
+  description: string | null;
+  duration: number | null;
+  time: string | null;    // HH:MM
+  status: 'pending' | 'completed' | 'archived';
+  is_archived: boolean;
+  urgency: 'high' | 'medium' | 'low';   // NEW
+}
+```
+
+---
+
+## TaskFormFields (new type)
+
+```typescript
+// Used by the add-task form and VoiceTaskInput
+interface TaskFormFields {
+  title: string;
+  description: string | null;
+  time: string | null;          // HH:MM
+  urgency: 'high' | 'medium' | 'low';
+  date: string;                 // YYYY-MM-DD, resolved from Today/Tomorrow toggle
+}
+```
+
+---
+
+## VoiceTaskInput Component
+
+```typescript
+// web/src/components/cyan/VoiceTaskInput.tsx
+interface VoiceTaskInputProps {
+  onExtracted: (fields: Partial<Omit<TaskFormFields, 'date'>>) => void;
+}
+```
+
+- Uses **Web Speech API (`SpeechRecognition`)** only — no `MediaRecorder`, no audio blob
+- **Manual stop** (button click) — no silence detection
+- Posts transcript to `/tasks/parse-voice` via `taskService.parseVoiceTranscript()`
+- States: `idle` → `recording` → `processing` → `done` / `error`
+
+**Error messages:**
+- Mic denied → "Microphone access denied"
+- 503 → "AI is warming up, try again in 30s"
+- Empty transcript → "Nothing captured, try again"
+- Bad JSON from Qwen → "Couldn't parse your task — please fill in manually"
+
+---
+
+## taskService Changes
+
+```typescript
+// web/src/services/taskService.ts
+
+// Unchanged — returns Task[] for today only
+getTasksForToday(): Promise<Task[]>
+
+// NEW — separate query: status=pending, date < today
+// Sort: date asc, then urgency (high→medium→low), then time asc
+getOverdueTasks(): Promise<Task[]>
+
+// Updated — now passes urgency and resolved date
+createTask(input: CreateTaskInput & { urgency: 'high' | 'medium' | 'low' }): Promise<Task>
+
+// Updated — now passes urgency
+updateTask(id: string, fields: Partial<TaskFormFields>): Promise<Task>
+
+// NEW — calls backend /tasks/parse-voice
+// Returns all 4 keys, null for fields Qwen can't extract
+parseVoiceTranscript(transcript: string): Promise<{
+  title: string | null;
+  description: string | null;
+  urgency: 'high' | 'medium' | 'low' | null;
+  time: string | null;
+}>
+```
+
+**Auth:** `taskService` currently calls Supabase directly. `parseVoiceTranscript` calls the FastAPI backend and needs Bearer auth. Use the shared helper from `web/src/services/auth.ts` (create this file if it doesn't exist yet):
+
+```typescript
+// web/src/services/auth.ts
+import { supabase } from './supabase';
+
+export async function getAuthHeaders(): Promise<Record<string, string>> {
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+```
+
+Also update `aiService.ts` to import from `auth.ts` instead of its local copy.
+
+---
+
+## TaskDashboard Changes
+
+```typescript
+// New state
+const [overdueTasks, setOverdueTasks] = useState<Task[]>([]);
+const [taskDate, setTaskDate] = useState<'today' | 'tomorrow'>('today');
+const [urgency, setUrgency] = useState<'high' | 'medium' | 'low'>('medium');
+
+// On mount — fetch both in parallel
+const [todayTasks, overdue] = await Promise.all([
+  taskService.getTasksForToday(),
+  taskService.getOverdueTasks(),
+]);
+
+// Date resolution for createTask
+const resolvedDate = taskDate === 'today'
+  ? new Date().toISOString().split('T')[0]
+  : new Date(Date.now() + 86400000).toISOString().split('T')[0];
+```
+
+**Render order:** Overdue section (hidden if empty) → Today section → Add Task form
+
+**Sorting within Today section:** High → Medium → Low, then time ascending, completed last.
+
+---
+
+## Backend: New Endpoint
+
+```python
+# POST /tasks/parse-voice — requires auth
+# Request: VoiceParseRequest(transcript: str)
+# Response: VoiceParseResponse(title, description, urgency, time — all Optional[str])
+
+# Qwen urgency inference:
+# high   → "urgent", "important", "asap", "critical", "can't wait", "must"
+# medium → "soon", "today", "need to", "should", implied time pressure; DEFAULT if unclear
+# low    → "whenever", "eventually", "maybe", no urgency signals
+```
+
+---
+
+## Backend: Schema Updates
+
+```python
+# TaskCreateRequest — add:
+urgency: Optional[str] = None   # "high" | "medium" | "low"
+
+# TaskUpdateRequest — add:
+urgency: Optional[str] = None   # "high" | "medium" | "low"
+
+# New models in schemas.py:
+class VoiceParseRequest(BaseModel):
+    transcript: str
+
+class VoiceParseResponse(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    urgency: Optional[str] = None
+    time: Optional[str] = None
+```
+
+---
+
+## Database Migration
+
+```sql
+-- /supabase/migrations/<timestamp>_add_task_urgency.sql
+ALTER TABLE tasks
+  ADD COLUMN urgency TEXT NOT NULL DEFAULT 'medium'
+  CHECK (urgency IN ('high', 'medium', 'low'));
+```
+
+`DEFAULT 'medium'` means existing rows are valid immediately — no backfill needed.
+
+---
+
+## Today/Tomorrow Toggle UI
+
+```tsx
+<div style={{ display: 'flex', background: '#0D0D0D', border: '1px solid #2A2A2A', borderRadius: '8px', overflow: 'hidden' }}>
+  {(['today', 'tomorrow'] as const).map(opt => (
+    <button
+      key={opt}
+      onClick={() => setTaskDate(opt)}
+      style={{
+        padding: '6px 14px',
+        fontSize: '11px',
+        fontWeight: 700,
+        border: 'none',
+        cursor: 'pointer',
+        background: taskDate === opt ? 'linear-gradient(135deg, #0099CC, #00FFFF)' : 'transparent',
+        color: taskDate === opt ? '#000' : '#BBC9CD',
+      }}
+    >
+      {opt.charAt(0).toUpperCase() + opt.slice(1)}
+    </button>
+  ))}
+</div>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ htmlcov/
 *.bak
 *.tmp
 
+# ----- Superpowers brainstorm sessions -----
+.superpowers/
+
 # ----- GitHub CLI & Workflow Artifacts -----
 gh_2.45.0_linux_amd64/
 gh_*.tar.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Web / Mobile → REST API → FastAPI (Cloud Run) → Supabase (PostgreSQL)
 | PATCH | `/chat/save/:id` | Pin AI response to permanent RAG memory |
 | GET/POST | `/tasks` | Daily task management |
 | PATCH | `/tasks/:id` | Update/archive task |
+| POST | `/tasks/parse-voice` | Voice transcript → structured task fields (Qwen extraction) |
 | GET | `/health` | Health metrics |
 
 ### Database (Supabase PostgreSQL)
@@ -81,11 +82,14 @@ Web / Mobile → REST API → FastAPI (Cloud Run) → Supabase (PostgreSQL)
 - `chat_history.is_saved = true` — bypasses 10-day auto-cleanup, permanent RAG knowledge
 - `pgvector` IVFFlat index for semantic search (1536-dim embeddings)
 - `pg_cron` auto-archives tasks at midnight
+- `tasks.urgency` — TEXT column: `'high' | 'medium' | 'low'`, DEFAULT `'medium'`
 
 ### Frontend Structure
 - Web (`/web/src`): components by feature (feeds, email, planner, chat, health, common), services (API clients), ThemeContext for OLED dark theme
 - Mobile (`/mobile/src`): 6 tab screens (Chat, Feeds, Email, Health, Planner, Settings), shared components, `theme.ts` for Figma-aligned OLED palette
 - Theme: OLED-optimized dark (deep blacks, slate grays), CSS variables in `web/src/styles/theme.css`
+- `web/src/services/auth.ts` — shared `getAuthHeaders()` helper (Supabase JWT); import this instead of duplicating in each service file
+- `web/src/components/cyan/VoiceTaskInput.tsx` — voice-to-task component (Web Speech API + Qwen extraction)
 
 ### Automation
 - **GitHub Actions `health_analysis.yml`**: daily cron at 8:00 AM GMT — pulls Samsung Watch data → Qwen analysis → stores in Supabase

--- a/backend/app/services/scrapers/adzuna.py
+++ b/backend/app/services/scrapers/adzuna.py
@@ -90,17 +90,20 @@ class AdzunaScraper:
 
             jobs = data.get("results", [])
             scraped_count = 0
+            job_ids: list[str] = []
 
             for job in jobs:
                 normalized = self._normalize_job(job, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate external_job_id
 
             logging.info(f"Adzuna scraped {scraped_count} jobs for campaign {campaign['id']}")
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"Adzuna scraping error: {e}")

--- a/backend/app/services/scrapers/crustdata.py
+++ b/backend/app/services/scrapers/crustdata.py
@@ -51,17 +51,20 @@ class CrustdataScraper:
                 
                 jobs = data.get("jobs", [])
                 scraped_count = 0
-                
+                job_ids: list[str] = []
+
                 for raw_job in jobs:
                     normalized = self._normalize_job(raw_job, campaign)
                     try:
-                        self.supabase.table("inbox_items").insert(normalized).execute()
+                        res = self.supabase.table("inbox_items").insert(normalized).execute()
                         scraped_count += 1
+                        if res.data and res.data[0].get("id"):
+                            job_ids.append(res.data[0]["id"])
                     except Exception:
                         # Likely a duplicate external_job_id — skip silently.
                         continue
-                
-                return {"scraped_count": scraped_count, "status": "success"}
+
+                return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"Crustdata API error: {e}")

--- a/backend/app/services/scrapers/cvlibrary.py
+++ b/backend/app/services/scrapers/cvlibrary.py
@@ -64,17 +64,20 @@ class CVLibraryScraper:
 
             jobs = data.get("jobs", data.get("results", []))
             scraped_count = 0
+            job_ids: list[str] = []
 
             for job in jobs[:max_results]:
                 normalized = self._normalize_job(job, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate
 
             logging.info(f"CV-Library scraped {scraped_count} jobs for campaign {campaign['id']}")
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"CV-Library scraping error: {e}")

--- a/backend/app/services/scrapers/embedding_scorer.py
+++ b/backend/app/services/scrapers/embedding_scorer.py
@@ -30,3 +30,47 @@ class EmbeddingScorer:
             return 0.0
         raw = dot / (norm_a * norm_b)
         return min(1.0, max(0.0, raw))
+
+    async def score_new_jobs(
+        self,
+        supabase,
+        user_id: str,
+        job_ids: list[str],
+    ) -> None:
+        """
+        Fetch CV embedding, embed job descriptions, update match scores.
+        Silently returns on any missing data or error.
+        """
+        if not job_ids:
+            return
+
+        # Fetch primary CV embedding
+        try:
+            res = (
+                supabase.table("cv_files")
+                .select("embedding")
+                .eq("user_id", user_id)
+                .eq("is_primary", True)
+                .limit(1)
+                .execute()
+            )
+        except Exception as e:
+            logger.warning(f"[EmbeddingScorer] CV fetch failed: {e}")
+            return
+
+        rows = res.data or []
+        if not rows or not rows[0].get("embedding"):
+            logger.info("[EmbeddingScorer] No primary CV embedding — skipping semantic scoring")
+            return
+
+        cv_embedding: list[float] = rows[0]["embedding"]
+        await self._embed_and_update(supabase, cv_embedding, job_ids)
+
+    async def _embed_and_update(
+        self,
+        supabase,
+        cv_embedding: list[float],
+        job_ids: list[str],
+    ) -> None:
+        # Placeholder — implemented in Task 3
+        pass

--- a/backend/app/services/scrapers/embedding_scorer.py
+++ b/backend/app/services/scrapers/embedding_scorer.py
@@ -1,0 +1,32 @@
+"""
+EmbeddingScorer — post-scrape semantic scoring.
+
+After scrapers insert jobs with keyword-based scores, this service:
+  1. Fetches the user's primary CV embedding from cv_files
+  2. Embeds each new job description concurrently (OpenAI text-embedding-3-small)
+  3. Computes cosine similarity
+  4. Updates inbox_items.match_score, match_reasoning, embedding
+
+Falls back silently to keyword scores if no CV is uploaded or any error occurs.
+"""
+import asyncio
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingScorer:
+
+    def _cosine_similarity(self, a: list[float], b: list[float]) -> float:
+        """
+        Cosine similarity in [0, 1]. Returns 0.0 for zero vectors.
+        Clamps result to [0.0, 1.0] to guard against float precision drift.
+        """
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = sum(x * x for x in a) ** 0.5
+        norm_b = sum(x * x for x in b) ** 0.5
+        if not norm_a or not norm_b:
+            return 0.0
+        raw = dot / (norm_a * norm_b)
+        return min(1.0, max(0.0, raw))

--- a/backend/app/services/scrapers/embedding_scorer.py
+++ b/backend/app/services/scrapers/embedding_scorer.py
@@ -72,5 +72,54 @@ class EmbeddingScorer:
         cv_embedding: list[float],
         job_ids: list[str],
     ) -> None:
-        # Placeholder — implemented in Task 3
-        pass
+        from app.services.cv_service import embed_text  # avoid circular import at module level
+
+        # Fetch all job descriptions in one query
+        try:
+            res = (
+                supabase.table("inbox_items")
+                .select("id, job_description")
+                .in_("id", job_ids)
+                .execute()
+            )
+        except Exception as e:
+            logger.warning(f"[EmbeddingScorer] Failed to fetch job descriptions: {e}")
+            return
+
+        jobs: list[dict] = res.data or []
+        if not jobs:
+            return
+
+        # Concurrently embed all job descriptions (semaphore cap = 20)
+        sem = asyncio.Semaphore(20)
+
+        async def embed_one(job_id: str, description: str):
+            async with sem:
+                return job_id, await embed_text(description)
+
+        raw_results = await asyncio.gather(
+            *[embed_one(j["id"], j.get("job_description", "")) for j in jobs],
+            return_exceptions=True,
+        )
+
+        # Update each job row with semantic score
+        for item in raw_results:
+            if isinstance(item, Exception):
+                logger.warning(f"[EmbeddingScorer] Embed failed for a job: {item}")
+                continue
+
+            job_id, job_embedding = item
+            if job_embedding is None:
+                continue
+
+            score = self._cosine_similarity(cv_embedding, job_embedding)
+            reasoning = f"Semantic similarity: {score:.2f} — CV embedding match via text-embedding-3-small"
+
+            try:
+                supabase.table("inbox_items").update({
+                    "match_score": round(score, 2),
+                    "match_reasoning": reasoning,
+                    "embedding": job_embedding,
+                }).eq("id", job_id).execute()
+            except Exception as e:
+                logger.warning(f"[EmbeddingScorer] Failed to update job {job_id}: {e}")

--- a/backend/app/services/scrapers/himalayas.py
+++ b/backend/app/services/scrapers/himalayas.py
@@ -37,17 +37,20 @@ class HimalayasScraper:
 
             jobs = data.get("jobs", [])
             scraped_count = 0
+            job_ids: list[str] = []
 
             for job in jobs[:max_results]:
                 normalized = self._normalize_job(job, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate
 
             logging.info(f"Himalayas scraped {scraped_count} jobs for campaign {campaign['id']}")
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"Himalayas scraping error: {e}")

--- a/backend/app/services/scrapers/jobicy.py
+++ b/backend/app/services/scrapers/jobicy.py
@@ -70,17 +70,20 @@ class JobicyScraper:
 
             jobs = data.get("jobs", [])
             scraped_count = 0
+            job_ids: list[str] = []
 
             for job in jobs[:max_results]:
                 normalized = self._normalize_job(job, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate
 
             logging.info(f"Jobicy scraped {scraped_count} jobs for campaign {campaign['id']}")
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"Jobicy scraping error: {e}")

--- a/backend/app/services/scrapers/multi_source_scraper.py
+++ b/backend/app/services/scrapers/multi_source_scraper.py
@@ -14,6 +14,7 @@ from .himalayas import HimalayasScraper
 from .reed import ReedScraper
 from .cvlibrary import CVLibraryScraper
 from .totaljobs import TotalJobsScraper
+from .embedding_scorer import EmbeddingScorer
 
 # Modified: 2026-03-22
 # What: Added _write_scrape_log() to persist execution evidence to the scrape_logs table after
@@ -77,6 +78,20 @@ class MultiSourceScraper:
                 self._write_scrape_log(campaign, scraper_name, count, started_at, completed_at, None)
 
         self._update_campaign_total(campaign["id"], total_scraped)
+
+        # Collect all newly inserted job IDs from scraper results
+        new_job_ids: list[str] = []
+        for res in results:
+            if isinstance(res, dict) and res.get("status") != "failed":
+                new_job_ids.extend(res.get("job_ids", []))
+
+        # Post-scrape semantic scoring — replaces keyword scores with CV embedding similarity
+        if new_job_ids:
+            try:
+                scorer = EmbeddingScorer()
+                await scorer.score_new_jobs(self.supabase, campaign["user_id"], new_job_ids)
+            except Exception as e:
+                logging.warning(f"[MultiSourceScraper] EmbeddingScorer failed: {e} — keyword scores retained")
 
         return {
             "scraped_count": total_scraped,

--- a/backend/app/services/scrapers/proxycurl.py
+++ b/backend/app/services/scrapers/proxycurl.py
@@ -45,13 +45,19 @@ class ProxycurlScraper:
                 
                 jobs = data.get("job_list", [])
                 scraped_count = 0
-                
+                job_ids: list[str] = []
+
                 for raw_job in jobs:
                     normalized = self._normalize_job(raw_job, campaign)
-                    self.supabase.table("inbox_items").insert(normalized).execute()
-                    scraped_count += 1
-                
-                return {"scraped_count": scraped_count, "status": "success"}
+                    try:
+                        res = self.supabase.table("inbox_items").insert(normalized).execute()
+                        scraped_count += 1
+                        if res.data and res.data[0].get("id"):
+                            job_ids.append(res.data[0]["id"])
+                    except Exception:
+                        continue  # duplicate or constraint violation
+
+                return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"Proxycurl API error: {e}")

--- a/backend/app/services/scrapers/reed.py
+++ b/backend/app/services/scrapers/reed.py
@@ -64,17 +64,20 @@ class ReedScraper:
 
             jobs = data.get("results", [])
             scraped_count = 0
+            job_ids: list[str] = []
 
             for job in jobs[:max_results]:
                 normalized = self._normalize_job(job, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate
 
             logging.info(f"Reed scraped {scraped_count} jobs for campaign {campaign['id']}")
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"Reed scraping error: {e}")

--- a/backend/app/services/scrapers/remoteok.py
+++ b/backend/app/services/scrapers/remoteok.py
@@ -39,6 +39,7 @@ class RemoteOKScraper:
             max_results = campaign.get("max_results_per_run", 50)
 
             scraped_count = 0
+            job_ids: list[str] = []
             for job in jobs[:max_results]:
                 # Client-side job_type filter: RemoteOK has no API param for it
                 if job_type:
@@ -50,13 +51,15 @@ class RemoteOKScraper:
                     continue
                 normalized = self._normalize_job(job, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate
 
             logging.info(f"RemoteOK scraped {scraped_count} jobs for campaign {campaign['id']}")
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"RemoteOK scraping error: {e}")

--- a/backend/app/services/scrapers/remotive.py
+++ b/backend/app/services/scrapers/remotive.py
@@ -41,6 +41,7 @@ class RemotiveScraper:
             max_results = campaign.get("max_results_per_run", 50)
 
             scraped_count = 0
+            job_ids: list[str] = []
             for job in jobs[:max_results]:
                 # Client-side job_type filter
                 if job_type:
@@ -49,13 +50,15 @@ class RemotiveScraper:
                         continue
                 normalized = self._normalize_job(job, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate
 
             logging.info(f"Remotive scraped {scraped_count} jobs for campaign {campaign['id']}")
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"Remotive scraping error: {e}")

--- a/backend/app/services/scrapers/serper.py
+++ b/backend/app/services/scrapers/serper.py
@@ -133,6 +133,7 @@ class SerperScraper:
 
             max_results = campaign.get("max_results_per_run", 50)
             scraped_count = 0
+            job_ids: list[str] = []
 
             # ── Insert Google Jobs first (structured, best quality) ───────────
             for job in google_jobs[:max_results]:
@@ -142,8 +143,10 @@ class SerperScraper:
                 # Add to seen so organic pass doesn't double-insert same URL
                 seen.add(normalized.get("job_url", ""))
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate
 
@@ -175,8 +178,10 @@ class SerperScraper:
             for result in validated_results:
                 normalized = self._normalize_result(result, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue
 
@@ -185,7 +190,7 @@ class SerperScraper:
                 f"→ {len(validated_results)} reachable | "
                 f"{len(google_jobs)} Google Jobs | {scraped_count} total inserted"
             )
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"Serper scraping error: {e}")

--- a/backend/app/services/scrapers/totaljobs.py
+++ b/backend/app/services/scrapers/totaljobs.py
@@ -68,17 +68,20 @@ class TotalJobsScraper:
 
             jobs = data.get("jobs", data.get("results", data if isinstance(data, list) else []))
             scraped_count = 0
+            job_ids: list[str] = []
 
             for job in jobs[:max_results]:
                 normalized = self._normalize_job(job, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     continue  # duplicate
 
             logging.info(f"TotalJobs scraped {scraped_count} jobs for campaign {campaign['id']}")
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"TotalJobs scraping error: {e}")

--- a/backend/app/services/scrapers/weworkremotely.py
+++ b/backend/app/services/scrapers/weworkremotely.py
@@ -78,6 +78,7 @@ class WeWorkRemotelyScraper:
             feed = await loop.run_in_executor(None, feedparser.parse, feed_url)
 
             scraped_count = 0
+            job_ids: list[str] = []
             max_results = campaign.get("max_results_per_run", 50)
 
             for entry in feed.entries:
@@ -90,13 +91,15 @@ class WeWorkRemotelyScraper:
                         continue
                 normalized = self._normalize_job(entry, campaign)
                 try:
-                    self.supabase.table("inbox_items").insert(normalized).execute()
+                    res = self.supabase.table("inbox_items").insert(normalized).execute()
                     scraped_count += 1
+                    if res.data and res.data[0].get("id"):
+                        job_ids.append(res.data[0]["id"])
                 except Exception:
                     # Likely a duplicate external_job_id — skip silently.
                     continue
 
-            return {"scraped_count": scraped_count, "status": "success"}
+            return {"scraped_count": scraped_count, "status": "success", "job_ids": job_ids}
 
         except Exception as e:
             logging.error(f"WeWorkRemotely Scraping error: {e}")

--- a/backend/tests/test_embedding_scorer.py
+++ b/backend/tests/test_embedding_scorer.py
@@ -31,3 +31,40 @@ class TestCosineSimilarity:
         result = scorer._cosine_similarity(v, v)
         assert result <= 1.0
         assert result >= 0.0
+
+
+class TestScoreNewJobsEarlyExit:
+    def _mock_supabase(self, cv_rows=None):
+        mock = MagicMock()
+        mock.table.return_value.select.return_value.eq.return_value\
+            .eq.return_value.limit.return_value.execute.return_value\
+            = MagicMock(data=cv_rows or [])
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_no_cv_rows_returns_early(self):
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+        supabase = self._mock_supabase(cv_rows=[])
+        # Should return without touching inbox_items
+        await scorer.score_new_jobs(supabase, "user-1", ["job-1"])
+        # inbox_items table never touched
+        table_calls = [c.args[0] for c in supabase.table.call_args_list]
+        assert "inbox_items" not in table_calls
+
+    @pytest.mark.asyncio
+    async def test_cv_without_embedding_returns_early(self):
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+        supabase = self._mock_supabase(cv_rows=[{"embedding": None}])
+        await scorer.score_new_jobs(supabase, "user-1", ["job-1"])
+        table_calls = [c.args[0] for c in supabase.table.call_args_list]
+        assert "inbox_items" not in table_calls
+
+    @pytest.mark.asyncio
+    async def test_empty_job_ids_returns_early(self):
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+        supabase = self._mock_supabase()
+        await scorer.score_new_jobs(supabase, "user-1", [])
+        supabase.table.assert_not_called()

--- a/backend/tests/test_embedding_scorer.py
+++ b/backend/tests/test_embedding_scorer.py
@@ -1,0 +1,33 @@
+"""Tests for EmbeddingScorer — cosine similarity and scoring logic."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors_return_1(self):
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+        v = [0.5, 0.5, 0.5, 0.5]
+        assert scorer._cosine_similarity(v, v) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors_return_0(self):
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+        a = [1.0, 0.0]
+        b = [0.0, 1.0]
+        assert scorer._cosine_similarity(a, b) == pytest.approx(0.0)
+
+    def test_zero_vector_returns_0(self):
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+        assert scorer._cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+    def test_float_precision_clamped_to_1(self):
+        """Vectors that are nearly identical may produce cosine slightly > 1.0 due to float precision."""
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+        # Force a value slightly over 1.0 by passing the same normalised vector
+        v = [1.0, 0.0]
+        result = scorer._cosine_similarity(v, v)
+        assert result <= 1.0
+        assert result >= 0.0

--- a/backend/tests/test_embedding_scorer.py
+++ b/backend/tests/test_embedding_scorer.py
@@ -68,3 +68,62 @@ class TestScoreNewJobsEarlyExit:
         supabase = self._mock_supabase()
         await scorer.score_new_jobs(supabase, "user-1", [])
         supabase.table.assert_not_called()
+
+
+class TestEmbedAndUpdate:
+    def _mock_supabase_with_cv(self, cv_embedding: list[float]):
+        mock = MagicMock()
+        # CV fetch
+        mock.table.return_value.select.return_value.eq.return_value\
+            .eq.return_value.limit.return_value.execute.return_value\
+            = MagicMock(data=[{"embedding": cv_embedding}])
+        # Job description fetch
+        mock.table.return_value.select.return_value.in_.return_value\
+            .execute.return_value\
+            = MagicMock(data=[
+                {"id": "job-1", "job_description": "Python FastAPI backend engineer"},
+                {"id": "job-2", "job_description": "React frontend developer"},
+            ])
+        # UPDATE
+        mock.table.return_value.update.return_value.eq.return_value\
+            .execute.return_value = MagicMock(data=[{}])
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_updates_match_score_for_each_job(self):
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+
+        cv_emb = [0.1] * 1536
+        job_emb = [0.1] * 1536  # identical → score ≈ 1.0
+
+        supabase = self._mock_supabase_with_cv(cv_emb)
+
+        with patch("app.services.cv_service.embed_text", new_callable=AsyncMock) as mock_embed:
+            mock_embed.return_value = job_emb
+            await scorer.score_new_jobs(supabase, "user-1", ["job-1", "job-2"])
+
+        # embed_text called once per job
+        assert mock_embed.call_count == 2
+
+        # UPDATE called once per job
+        update_calls = [
+            c for c in supabase.table.call_args_list
+            if c.args[0] == "inbox_items"
+        ]
+        # At least 2 inbox_items table calls (one SELECT for descriptions + 2 UPDATEs)
+        assert len(update_calls) >= 2
+
+    @pytest.mark.asyncio
+    async def test_embed_failure_skips_job_gracefully(self):
+        from app.services.scrapers.embedding_scorer import EmbeddingScorer
+        scorer = EmbeddingScorer()
+
+        cv_emb = [0.1] * 1536
+        supabase = self._mock_supabase_with_cv(cv_emb)
+
+        with patch("app.services.cv_service.embed_text", new_callable=AsyncMock) as mock_embed:
+            # First call fails, second succeeds
+            mock_embed.side_effect = [Exception("OpenAI timeout"), [0.1] * 1536]
+            # Should not raise
+            await scorer.score_new_jobs(supabase, "user-1", ["job-1", "job-2"])

--- a/backend/tests/test_jobs_pipeline.py
+++ b/backend/tests/test_jobs_pipeline.py
@@ -305,13 +305,13 @@ class TestMultiSourceScraper:
         # Patch all child scrapers to return controlled results
         for child in scraper.scrapers:
             child.scrape_jobs_for_campaign = AsyncMock(
-                return_value={"scraped_count": 3, "status": "success"}
+                return_value={"scraped_count": 3, "status": "success", "job_ids": []}
             )
 
         result = await scraper.scrape_jobs_for_campaign(CAMPAIGN)
 
         assert result["status"] == "success"
-        assert result["scraped_count"] == 12  # 4 scrapers × 3 each
+        assert result["scraped_count"] == 36  # 12 scrapers × 3 each
         assert result["errors"] is None
 
     @pytest.mark.asyncio
@@ -346,7 +346,7 @@ class TestMultiSourceScraper:
 
         for child in scraper.scrapers:
             child.scrape_jobs_for_campaign = AsyncMock(
-                return_value={"scraped_count": 2, "status": "success"}
+                return_value={"scraped_count": 2, "status": "success", "job_ids": []}
             )
 
         await scraper.scrape_jobs_for_campaign(CAMPAIGN)
@@ -355,8 +355,8 @@ class TestMultiSourceScraper:
             call for call in supabase.table.call_args_list
             if call.args[0] == "scrape_logs"
         ]
-        # One log entry per scraper (4 scrapers)
-        assert len(scrape_log_calls) == 4
+        # One log entry per scraper (12 scrapers)
+        assert len(scrape_log_calls) == 12
 
     @pytest.mark.asyncio
     async def test_exception_from_scraper_captured(self):
@@ -369,7 +369,7 @@ class TestMultiSourceScraper:
         scraper.scrapers[0].scrape_jobs_for_campaign = AsyncMock(side_effect=RuntimeError("boom"))
         for child in scraper.scrapers[1:]:
             child.scrape_jobs_for_campaign = AsyncMock(
-                return_value={"scraped_count": 1, "status": "success"}
+                return_value={"scraped_count": 1, "status": "success", "job_ids": []}
             )
 
         result = await scraper.scrape_jobs_for_campaign(CAMPAIGN)
@@ -398,7 +398,7 @@ class TestMultiSourceScraper:
 
         for child in scraper.scrapers:
             child.scrape_jobs_for_campaign = AsyncMock(
-                return_value={"scraped_count": 0, "status": "success"}
+                return_value={"scraped_count": 0, "status": "success", "job_ids": []}
             )
 
         # Just validate the normalizer output from each scraper directly
@@ -425,3 +425,52 @@ class TestMultiSourceScraper:
                   "job_url": "https://li.com/2", "job_description": "desc"}
         pc_norm = ProxycurlScraper(supabase)._normalize_job(pc_job, CAMPAIGN)
         assert pc_norm["match_score"] is not None
+
+
+# ---------------------------------------------------------------------------
+# TestScraperReturnsJobIds
+# ---------------------------------------------------------------------------
+
+class TestScraperReturnsJobIds:
+    @pytest.mark.asyncio
+    async def test_weworkremotely_returns_job_ids(self):
+        """Scraper result dict must include job_ids list after successful inserts."""
+        from app.services.scrapers.weworkremotely import WeWorkRemotelyScraper
+
+        mock_feed = MagicMock()
+        mock_feed.entries = [
+            MagicMock(title="Co: Job A", link="https://wwr.com/1", id="wwr-1", description="desc"),
+        ]
+
+        supabase = _mock_supabase()  # already returns data=[{"id": "row-1"}]
+        scraper = WeWorkRemotelyScraper(supabase)
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(return_value=mock_feed)
+            result = await scraper.scrape_jobs_for_campaign(CAMPAIGN)
+
+        assert "job_ids" in result
+        assert result["job_ids"] == ["row-1"]
+
+    @pytest.mark.asyncio
+    async def test_job_ids_empty_when_all_duplicates(self):
+        """Duplicate inserts must not add IDs to job_ids."""
+        from app.services.scrapers.weworkremotely import WeWorkRemotelyScraper
+
+        mock_feed = MagicMock()
+        mock_feed.entries = [
+            MagicMock(title="Co: Job A", link="https://wwr.com/1", id="wwr-1", description="desc"),
+        ]
+
+        supabase = _mock_supabase()
+        supabase.table.return_value.insert.return_value.execute.side_effect = [
+            Exception("duplicate key value violates unique constraint"),
+        ]
+        scraper = WeWorkRemotelyScraper(supabase)
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(return_value=mock_feed)
+            result = await scraper.scrape_jobs_for_campaign(CAMPAIGN)
+
+        assert result["job_ids"] == []
+        assert result["scraped_count"] == 0

--- a/backend/tests/test_jobs_pipeline.py
+++ b/backend/tests/test_jobs_pipeline.py
@@ -474,3 +474,78 @@ class TestScraperReturnsJobIds:
 
         assert result["job_ids"] == []
         assert result["scraped_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# TestMultiSourceScraperEmbedding
+# ---------------------------------------------------------------------------
+
+class TestMultiSourceScraperEmbedding:
+    @pytest.mark.asyncio
+    async def test_embedding_scorer_called_with_collected_job_ids(self):
+        """MultiSourceScraper must call EmbeddingScorer with all job IDs after scrape."""
+        from app.services.scrapers.multi_source_scraper import MultiSourceScraper
+
+        supabase = _mock_supabase()
+        scraper = MultiSourceScraper(supabase)
+
+        for child in scraper.scrapers:
+            child.scrape_jobs_for_campaign = AsyncMock(
+                return_value={"scraped_count": 1, "status": "success", "job_ids": ["job-abc"]}
+            )
+
+        with patch("app.services.scrapers.multi_source_scraper.EmbeddingScorer") as MockScorer:
+            mock_instance = AsyncMock()
+            MockScorer.return_value = mock_instance
+
+            await scraper.scrape_jobs_for_campaign(CAMPAIGN)
+
+        mock_instance.score_new_jobs.assert_called_once()
+        call_args = mock_instance.score_new_jobs.call_args
+        # user_id passed correctly
+        assert call_args.args[1] == CAMPAIGN["user_id"]
+        # all job IDs from all scrapers collected
+        collected_ids = call_args.args[2]
+        assert len(collected_ids) == 12  # 12 scrapers × 1 job each
+        assert "job-abc" in collected_ids
+
+    @pytest.mark.asyncio
+    async def test_embedding_scorer_failure_does_not_fail_scrape(self):
+        """If EmbeddingScorer raises, the scrape result must still succeed."""
+        from app.services.scrapers.multi_source_scraper import MultiSourceScraper
+
+        supabase = _mock_supabase()
+        scraper = MultiSourceScraper(supabase)
+
+        for child in scraper.scrapers:
+            child.scrape_jobs_for_campaign = AsyncMock(
+                return_value={"scraped_count": 1, "status": "success", "job_ids": ["job-abc"]}
+            )
+
+        with patch("app.services.scrapers.multi_source_scraper.EmbeddingScorer") as MockScorer:
+            mock_instance = AsyncMock()
+            mock_instance.score_new_jobs.side_effect = Exception("OpenAI down")
+            MockScorer.return_value = mock_instance
+
+            result = await scraper.scrape_jobs_for_campaign(CAMPAIGN)
+
+        assert result["status"] == "success"
+        assert result["scraped_count"] == 12
+
+    @pytest.mark.asyncio
+    async def test_no_job_ids_skips_embedding_scorer(self):
+        """If no job IDs collected (all duplicates), EmbeddingScorer must not be called."""
+        from app.services.scrapers.multi_source_scraper import MultiSourceScraper
+
+        supabase = _mock_supabase()
+        scraper = MultiSourceScraper(supabase)
+
+        for child in scraper.scrapers:
+            child.scrape_jobs_for_campaign = AsyncMock(
+                return_value={"scraped_count": 0, "status": "success", "job_ids": []}
+            )
+
+        with patch("app.services.scrapers.multi_source_scraper.EmbeddingScorer") as MockScorer:
+            await scraper.scrape_jobs_for_campaign(CAMPAIGN)
+
+        MockScorer.assert_not_called()

--- a/docs/superpowers/plans/2026-03-23-task-dashboard-redesign.md
+++ b/docs/superpowers/plans/2026-03-23-task-dashboard-redesign.md
@@ -1,0 +1,1161 @@
+# Task Dashboard Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **REQUIRED SKILLS:** Load `supercyan-frontend` and `supercyan-task-feature` before touching any file.
+
+**Goal:** Upgrade `TaskDashboard` with urgency levels, overdue carry-forward, a Today/Tomorrow date toggle, and a voice-to-task feature backed by a new Qwen extraction endpoint.
+
+**Architecture:** A new `VoiceTaskInput` component handles recording + Qwen extraction; `TaskDashboard` is enhanced in-place with urgency display, overdue detection, and form updates. A shared `auth.ts` utility is extracted from `aiService.ts` to avoid duplication. Backend gets two schema additions and one new endpoint.
+
+**Tech Stack:** React + TypeScript (Vite), Web Speech API (`SpeechRecognition`), Python FastAPI, Supabase PostgreSQL, Qwen3-Coder-30B via vLLM (OpenAI-compatible)
+
+**Spec:** `docs/superpowers/specs/2026-03-23-task-dashboard-redesign.md`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `supabase/migrations/20260323000007_add_task_urgency.sql` | Add `urgency` column to `tasks` table |
+| Create | `supabase/migrations/20260323000007_add_task_urgency_down.sql` | Rollback migration |
+| Create | `web/src/services/auth.ts` | Shared `getAuthHeaders()` Supabase JWT helper |
+| Modify | `web/src/services/aiService.ts` | Import `getAuthHeaders` from `auth.ts` |
+| Modify | `web/src/types/tasks.ts` | Add `urgency` field to `Task` + `TaskFormFields` type |
+| Modify | `backend/app/models/schemas.py` | Add `VoiceParseRequest`, `VoiceParseResponse` |
+| Modify | `backend/app/api/v1/endpoints.py` | Add `urgency` to `TaskCreateRequest`/`TaskUpdateRequest`; add `POST /tasks/parse-voice` |
+| Create | `backend/tests/test_tasks.py` | Tests for `parse-voice` endpoint |
+| Modify | `web/src/services/taskService.ts` | `getOverdueTasks()`, urgency in create/update, `parseVoiceTranscript()` |
+| Create | `web/src/components/cyan/VoiceTaskInput.tsx` | Voice recording + Qwen extraction component |
+| Modify | `web/src/components/cyan/TaskDashboard.tsx` | Urgency display, overdue section, Today/Tomorrow toggle, voice integration |
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+- Create: `supabase/migrations/20260323000007_add_task_urgency.sql`
+- Create: `supabase/migrations/20260323000007_add_task_urgency_down.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- supabase/migrations/20260323000007_add_task_urgency.sql
+ALTER TABLE tasks
+  ADD COLUMN urgency TEXT NOT NULL DEFAULT 'medium'
+  CHECK (urgency IN ('high', 'medium', 'low'));
+```
+
+- [ ] **Step 2: Write the rollback**
+
+```sql
+-- supabase/migrations/20260323000007_add_task_urgency_down.sql
+ALTER TABLE tasks DROP COLUMN IF EXISTS urgency;
+```
+
+- [ ] **Step 3: Apply via Supabase dashboard or CLI**
+
+If using CLI: `supabase db push`
+If using dashboard: paste the SQL into the SQL editor and run it.
+
+Verify: query `SELECT urgency FROM tasks LIMIT 1;` — should return `medium` for existing rows.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260323000007_add_task_urgency.sql \
+        supabase/migrations/20260323000007_add_task_urgency_down.sql
+git commit -m "feat(db): add urgency column to tasks table"
+```
+
+---
+
+## Task 2: Shared Auth Utility
+
+**Files:**
+- Create: `web/src/services/auth.ts`
+- Modify: `web/src/services/aiService.ts`
+
+- [ ] **Step 1: Create `auth.ts`**
+
+```typescript
+// web/src/services/auth.ts
+import { supabase } from './supabase';
+
+export async function getAuthHeaders(): Promise<Record<string, string>> {
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+```
+
+- [ ] **Step 2: Update `aiService.ts` to import from `auth.ts`**
+
+Remove the local `getAuthHeaders` function definition and replace with an import:
+
+```typescript
+// Remove this from aiService.ts:
+// async function getAuthHeaders(): Promise<Record<string, string>> { ... }
+
+// Add at top of imports:
+import { getAuthHeaders } from './auth';
+```
+
+The rest of `aiService.ts` is unchanged — the function signature is identical.
+
+- [ ] **Step 3: Verify the app still compiles**
+
+```bash
+cd web && npm run build
+```
+Expected: no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/services/auth.ts web/src/services/aiService.ts
+git commit -m "refactor: extract getAuthHeaders into shared auth.ts utility"
+```
+
+---
+
+## Task 3: Backend Schema Updates
+
+**Files:**
+- Modify: `backend/app/models/schemas.py`
+- Modify: `backend/app/api/v1/endpoints.py` (schema classes only, lines ~73-87)
+
+- [ ] **Step 1: Add `VoiceParseRequest` and `VoiceParseResponse` to `schemas.py`**
+
+```python
+# backend/app/models/schemas.py — append to existing models
+
+class VoiceParseRequest(BaseModel):
+    transcript: str
+
+class VoiceParseResponse(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    urgency: Optional[str] = None   # "high" | "medium" | "low"
+    time: Optional[str] = None      # HH:MM or null
+```
+
+- [ ] **Step 2: Add `urgency` to `TaskCreateRequest` in `endpoints.py`**
+
+Find the `TaskCreateRequest` class (around line 73) and add the field:
+
+```python
+class TaskCreateRequest(BaseModel):
+    title: str
+    description: Optional[str] = None
+    duration: Optional[int] = None
+    time: Optional[str] = None
+    date: Optional[str] = None
+    urgency: Optional[str] = None   # ADD — "high" | "medium" | "low"
+```
+
+- [ ] **Step 3: Add `urgency` to `TaskUpdateRequest` in `endpoints.py`**
+
+Find the `TaskUpdateRequest` class and add the field:
+
+```python
+class TaskUpdateRequest(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    duration: Optional[int] = None
+    time: Optional[str] = None
+    status: Optional[str] = None
+    is_archived: Optional[bool] = None
+    urgency: Optional[str] = None   # ADD — "high" | "medium" | "low"
+```
+
+- [ ] **Step 4: Verify backend starts cleanly**
+
+```bash
+cd backend && source .venv/bin/activate
+uvicorn app.main:app --reload
+```
+Expected: server starts, no import errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/models/schemas.py backend/app/api/v1/endpoints.py
+git commit -m "feat(backend): add urgency to task schemas + VoiceParse models"
+```
+
+---
+
+## Task 4: `/tasks/parse-voice` Endpoint + Tests
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints.py` (new route)
+- Create: `backend/tests/test_tasks.py`
+
+- [ ] **Step 1: Write the failing tests first**
+
+```python
+# backend/tests/test_tasks.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from app.main import app
+from app.utils.config import settings
+from jose import jwt
+import time
+
+client = TestClient(app)
+TEST_SECRET = "test-secret-for-unit-tests-only"
+
+
+def _make_token(sub: str = "test-user-uuid") -> str:
+    payload = {
+        "sub": sub,
+        "aud": "authenticated",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+    }
+    return jwt.encode(payload, TEST_SECRET, algorithm="HS256")
+
+
+def _auth_header():
+    return {"Authorization": f"Bearer {_make_token()}"}
+
+
+def test_parse_voice_requires_auth(monkeypatch):
+    monkeypatch.setattr(settings, "supabase_jwt_secret", TEST_SECRET)
+    response = client.post(
+        "/api/v1/tasks/parse-voice",
+        json={"transcript": "Call the accountant tomorrow"},
+    )
+    assert response.status_code == 401
+
+
+def test_parse_voice_returns_structured_fields(monkeypatch):
+    monkeypatch.setattr(settings, "supabase_jwt_secret", TEST_SECRET)
+
+    # The endpoint calls httpx directly — mock at the transport level
+    import httpx
+    from unittest.mock import MagicMock
+
+    mock_qwen_body = '{"choices":[{"message":{"content":"{\\"title\\":\\"Call the accountant\\",\\"description\\":null,\\"urgency\\":\\"high\\",\\"time\\":null}"}}]}'
+
+    mock_http_response = MagicMock()
+    mock_http_response.status_code = 200
+    mock_http_response.json.return_value = {
+        "choices": [{"message": {"content": '{"title":"Call the accountant","description":null,"urgency":"high","time":null}'}}]
+    }
+    mock_http_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_http_response):
+        response = client.post(
+            "/api/v1/tasks/parse-voice",
+            headers=_auth_header(),
+            json={"transcript": "Call the accountant, it's really important"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert "title" in data
+    assert "urgency" in data
+    assert "description" in data
+    assert "time" in data
+
+
+def test_parse_voice_rejects_empty_transcript(monkeypatch):
+    monkeypatch.setattr(settings, "supabase_jwt_secret", TEST_SECRET)
+    response = client.post(
+        "/api/v1/tasks/parse-voice",
+        headers=_auth_header(),
+        json={"transcript": ""},
+    )
+    assert response.status_code == 422
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd backend && source .venv/bin/activate
+pytest tests/test_tasks.py -v
+```
+Expected: `test_parse_voice_requires_auth` → FAIL (route doesn't exist), others fail too.
+
+- [ ] **Step 3: Implement the endpoint in `endpoints.py`**
+
+Add this route after the existing task routes. Import `VoiceParseRequest` and `VoiceParseResponse` from `app.models.schemas`:
+
+```python
+@router.post("/tasks/parse-voice", response_model=schemas.VoiceParseResponse)
+async def parse_voice_task(
+    request: schemas.VoiceParseRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Extract structured task fields from a voice transcript using Qwen."""
+    if not request.transcript.strip():
+        raise HTTPException(status_code=422, detail="Transcript cannot be empty")
+
+    system_prompt = """You are a task extraction assistant. Given a voice transcript, extract the following fields as JSON:
+- title: short imperative task name (required, max 80 chars)
+- description: any extra detail beyond the title (null if none)
+- urgency: "high", "medium", or "low" based on these signals:
+    high — "urgent", "important", "asap", "critical", "can't wait", "must"
+    medium — "soon", "today", "need to", "should", implied time pressure; DEFAULT if unclear
+    low — "whenever", "eventually", "maybe", no urgency signals
+- time: 24-hour HH:MM if a time is mentioned (null otherwise)
+
+Return only valid JSON with exactly these four keys. No explanation."""
+
+    try:
+        qwen_url = settings.qwen_endpoint_url
+        headers = {"Content-Type": "application/json", **_get_gcp_headers(qwen_url)}
+        payload = {
+            "model": settings.qwen_model_name,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": request.transcript},
+            ],
+            "temperature": 0.1,
+            "max_tokens": 200,
+        }
+        async with httpx.AsyncClient(timeout=30) as client_http:
+            resp = await client_http.post(
+                f"{qwen_url}/chat/completions",
+                headers=headers,
+                json=payload,
+            )
+            resp.raise_for_status()
+
+        raw = resp.json()["choices"][0]["message"]["content"].strip()
+
+        # Strip markdown code fences if present
+        if raw.startswith("```"):
+            raw = raw.split("```")[1]
+            if raw.startswith("json"):
+                raw = raw[4:]
+
+        import json as _json
+        parsed = _json.loads(raw)
+
+        return schemas.VoiceParseResponse(
+            title=parsed.get("title"),
+            description=parsed.get("description"),
+            urgency=parsed.get("urgency"),
+            time=parsed.get("time"),
+        )
+
+    except Exception as e:
+        print(f"[ParseVoice] Error: {e}")
+        return schemas.VoiceParseResponse(
+            title=None, description=None, urgency=None, time=None
+        )
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+pytest tests/test_tasks.py -v
+```
+Expected: all 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints.py backend/tests/test_tasks.py
+git commit -m "feat(backend): add POST /tasks/parse-voice endpoint with Qwen extraction"
+```
+
+---
+
+## Task 5: Frontend Types
+
+**Files:**
+- Modify: `web/src/types/tasks.ts`
+
+- [ ] **Step 1: Add `urgency` to the `Task` interface and add `TaskFormFields`**
+
+```typescript
+// web/src/types/tasks.ts
+
+export interface Task {
+  id: string;
+  user_id: string;
+  date: string;
+  title: string;
+  description: string | null;
+  duration: number | null;
+  time: string | null;
+  status: 'pending' | 'completed' | 'archived';
+  is_archived: boolean;
+  urgency: 'high' | 'medium' | 'low';   // NEW
+}
+
+export type CreateTaskInput = Omit<Task, 'id' | 'user_id' | 'status' | 'is_archived'>;
+
+// NEW — used by the add-task form and VoiceTaskInput
+export interface TaskFormFields {
+  title: string;
+  description: string | null;
+  time: string | null;
+  urgency: 'high' | 'medium' | 'low';
+  date: string;   // YYYY-MM-DD, resolved from Today/Tomorrow toggle
+}
+```
+
+- [ ] **Step 2: Check for TypeScript errors**
+
+```bash
+cd web && npm run build 2>&1 | grep -i error
+```
+Expected: no new errors (existing code that creates tasks without urgency will be fine since the DB default is 'medium').
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/types/tasks.ts
+git commit -m "feat(types): add urgency to Task type + TaskFormFields interface"
+```
+
+---
+
+## Task 6: taskService Updates
+
+**Files:**
+- Modify: `web/src/services/taskService.ts`
+
+- [ ] **Step 1: Read the current file to understand existing patterns**
+
+Read `web/src/services/taskService.ts` in full before making any changes.
+
+- [ ] **Step 2: Add `getOverdueTasks()`**
+
+Add after `getTasksForToday()`:
+
+```typescript
+getOverdueTasks: async (): Promise<Task[]> => {
+  const today = new Date().toISOString().split('T')[0];
+  const { data, error } = await supabase
+    .from('tasks')
+    .select('*')
+    .eq('status', 'pending')
+    .eq('is_archived', false)
+    .lt('date', today)
+    .order('date', { ascending: true });
+
+  if (error) throw error;
+
+  // Sort: date asc (already from DB), then urgency (high→medium→low), then time
+  const urgencyOrder = { high: 0, medium: 1, low: 2 };
+  return (data as Task[]).sort((a, b) => {
+    if (a.date !== b.date) return a.date.localeCompare(b.date);
+    const uDiff = urgencyOrder[a.urgency] - urgencyOrder[b.urgency];
+    if (uDiff !== 0) return uDiff;
+    if (a.time && b.time) return a.time.localeCompare(b.time);
+    return 0;
+  });
+},
+```
+
+- [ ] **Step 3: Update `createTask()` to pass urgency**
+
+In the existing `createTask()`, add `urgency` to the insert object:
+
+```typescript
+const { data, error } = await supabase
+  .from('tasks')
+  .insert([{
+    ...input,
+    urgency: input.urgency ?? 'medium',   // ADD — use provided value or default
+    status: 'pending',
+    is_archived: false,
+  }])
+  .select()
+  .single();
+```
+
+- [ ] **Step 4: Update `updateTask()` to pass urgency (if not already a generic patch)**
+
+If `updateTask()` only passes specific fields, ensure `urgency` is included in the update payload when provided:
+
+```typescript
+updateTask: async (taskId: string, updates: Partial<Task>): Promise<void> => {
+  const { error } = await supabase
+    .from('tasks')
+    .update(updates)   // passes urgency if present in updates
+    .eq('id', taskId);
+  if (error) throw error;
+},
+```
+
+- [ ] **Step 5: Add `parseVoiceTranscript()`**
+
+Import `getAuthHeaders` and the backend URL, then add:
+
+```typescript
+import { getAuthHeaders } from './auth';
+
+const BACKEND_URL = import.meta.env.VITE_CLOUD_GATEWAY_URL || 'http://localhost:8000/api/v1';
+
+// Inside the taskService object:
+parseVoiceTranscript: async (transcript: string): Promise<{
+  title: string | null;
+  description: string | null;
+  urgency: 'high' | 'medium' | 'low' | null;
+  time: string | null;
+}> => {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`${BACKEND_URL}/tasks/parse-voice`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ transcript }),
+  });
+  if (response.status === 503) throw new Error('warming');
+  if (!response.ok) throw new Error('parse-voice failed');
+  return response.json();
+},
+```
+
+- [ ] **Step 6: Verify types compile**
+
+```bash
+cd web && npm run build 2>&1 | grep -i error
+```
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/services/taskService.ts
+git commit -m "feat(taskService): add getOverdueTasks, urgency in create/update, parseVoiceTranscript"
+```
+
+---
+
+## Task 7: VoiceTaskInput Component
+
+**Files:**
+- Create: `web/src/components/cyan/VoiceTaskInput.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```typescript
+// web/src/components/cyan/VoiceTaskInput.tsx
+import React, { useState, useRef } from 'react';
+import { Mic, MicOff, Loader2 } from 'lucide-react';
+import { taskService } from '../../services/taskService';
+import { TaskFormFields } from '../../types/tasks';
+
+interface VoiceTaskInputProps {
+  onExtracted: (fields: Partial<Omit<TaskFormFields, 'date'>>) => void;
+}
+
+type VoiceState = 'idle' | 'recording' | 'processing' | 'done' | 'error';
+
+export default function VoiceTaskInput({ onExtracted }: VoiceTaskInputProps) {
+  const [state, setState] = useState<VoiceState>('idle');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+  const [transcript, setTranscript] = useState<string>('');
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  const startRecording = () => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+
+    if (!SpeechRecognition) {
+      setErrorMsg('Speech recognition is not supported in this browser.');
+      setState('error');
+      return;
+    }
+
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = 'en-GB';
+    recognitionRef.current = recognition;
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let full = '';
+      for (let i = 0; i < event.results.length; i++) {
+        full += event.results[i][0].transcript;
+      }
+      setTranscript(full);
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error === 'not-allowed') {
+        setErrorMsg('Microphone access denied.');
+      } else {
+        setErrorMsg('Recording error — please try again.');
+      }
+      setState('error');
+    };
+
+    recognition.start();
+    setState('recording');
+    setTranscript('');
+    setErrorMsg('');
+  };
+
+  const stopRecording = async () => {
+    recognitionRef.current?.stop();
+    recognitionRef.current = null;
+
+    if (!transcript.trim()) {
+      setErrorMsg('Nothing captured, try again.');
+      setState('error');
+      return;
+    }
+
+    setState('processing');
+    try {
+      const fields = await taskService.parseVoiceTranscript(transcript);
+
+      if (!fields.title) {
+        setErrorMsg("Couldn't parse your task — please fill in manually.");
+        setState('error');
+        return;
+      }
+
+      onExtracted({
+        title: fields.title ?? undefined,
+        description: fields.description ?? undefined,
+        urgency: fields.urgency ?? 'medium',
+        time: fields.time ?? undefined,
+      });
+      setState('done');
+      setTranscript('');
+    } catch (err: any) {
+      const msg =
+        err?.message === 'warming'
+          ? 'AI is warming up, try again in 30s.'
+          : 'Voice parsing failed — please fill in manually.';
+      setErrorMsg(msg);
+      setState('error');
+    }
+  };
+
+  const reset = () => {
+    setState('idle');
+    setErrorMsg('');
+    setTranscript('');
+  };
+
+  const isRecording = state === 'recording';
+  const isProcessing = state === 'processing';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <button
+          onClick={isRecording ? stopRecording : startRecording}
+          disabled={isProcessing}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            padding: '6px 14px',
+            borderRadius: '8px',
+            border: 'none',
+            cursor: isProcessing ? 'not-allowed' : 'pointer',
+            fontWeight: 700,
+            fontSize: '12px',
+            background: isRecording
+              ? 'rgba(255,68,68,0.15)'
+              : 'linear-gradient(135deg, #0099CC, #00FFFF)',
+            color: isRecording ? '#FF4444' : '#000',
+            border: isRecording ? '1px solid rgba(255,68,68,0.4)' : 'none',
+          }}
+        >
+          {isProcessing ? (
+            <Loader2 size={14} style={{ animation: 'spin 1s linear infinite' }} />
+          ) : isRecording ? (
+            <MicOff size={14} />
+          ) : (
+            <Mic size={14} />
+          )}
+          {isProcessing ? 'Processing...' : isRecording ? 'Stop' : '🎤 Voice'}
+        </button>
+
+        {state === 'done' && (
+          <span style={{ fontSize: '12px', color: '#00FFFF' }}>✓ Fields filled</span>
+        )}
+        {state === 'error' && (
+          <button
+            onClick={reset}
+            style={{ fontSize: '11px', color: '#BBC9CD', background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline' }}
+          >
+            Retry
+          </button>
+        )}
+      </div>
+
+      {isRecording && transcript && (
+        <div style={{
+          fontSize: '11px',
+          color: '#BBC9CD',
+          background: '#0D0D0D',
+          border: '1px solid #2A2A2A',
+          borderRadius: '6px',
+          padding: '6px 10px',
+          fontStyle: 'italic',
+        }}>
+          "{transcript}"
+        </div>
+      )}
+
+      {state === 'error' && errorMsg && (
+        <div style={{ fontSize: '11px', color: '#FF4444' }}>{errorMsg}</div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd web && npm run build 2>&1 | grep -i error
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/components/cyan/VoiceTaskInput.tsx
+git commit -m "feat(web): add VoiceTaskInput component (Web Speech API + Qwen extraction)"
+```
+
+---
+
+## Task 8: TaskDashboard — Urgency Display + Overdue Section
+
+**Files:**
+- Modify: `web/src/components/cyan/TaskDashboard.tsx`
+
+> Read the full `TaskDashboard.tsx` before making changes. Load `supercyan-task-feature` skill for colour references.
+
+- [ ] **Step 1: Add new state variables**
+
+At the top of the component (after existing state declarations), add:
+
+```typescript
+const [overdueTasks, setOverdueTasks] = useState<Task[]>([]);
+```
+
+- [ ] **Step 2: Update `fetchTasks` to also fetch overdue tasks**
+
+```typescript
+const fetchTasks = async () => {
+  setLoading(true);
+  try {
+    const [todayData, overdueData] = await Promise.all([
+      taskService.getTasksForToday(),
+      taskService.getOverdueTasks(),
+    ]);
+    setTasks(todayData);
+    setOverdueTasks(overdueData);
+  } catch (err) {
+    console.error('[TaskDashboard] fetch error:', err);
+  } finally {
+    setLoading(false);
+  }
+};
+```
+
+- [ ] **Step 3: Add urgency helper functions**
+
+```typescript
+const urgencyBorderColor = (urgency: Task['urgency']) => {
+  if (urgency === 'high') return '#FF4444';
+  if (urgency === 'medium') return '#D97706';
+  return '#4499DD';
+};
+
+const urgencyBadgeStyle = (urgency: Task['urgency']): React.CSSProperties => {
+  const map = {
+    high: { color: '#FF4444', background: 'rgba(255,68,68,0.12)' },
+    medium: { color: '#D97706', background: 'rgba(217,119,6,0.12)' },
+    low: { color: '#4499DD', background: 'rgba(68,153,221,0.12)' },
+  };
+  return { ...map[urgency], fontSize: '10px', fontWeight: 700, borderRadius: '4px', padding: '1px 6px' };
+};
+```
+
+- [ ] **Step 4: Update task card rendering to show urgency**
+
+In the task list render, update each task card to use `urgencyBorderColor`:
+
+```tsx
+// Task card container — replace hardcoded border with:
+style={{
+  borderLeft: `3px solid ${task.status === 'completed' ? '#333' : urgencyBorderColor(task.urgency ?? 'low')}`,
+  background: task.status === 'completed' ? '#0F0F0F' : '#1A1A1A',
+  opacity: task.status === 'completed' ? 0.5 : 1,
+  // ... keep existing padding, borderRadius, etc.
+}}
+
+// Add urgency badge inside the card next to the title:
+<span style={urgencyBadgeStyle(task.urgency ?? 'low')}>
+  {(task.urgency ?? 'low').toUpperCase()}
+</span>
+```
+
+- [ ] **Step 5: Add the overdue section above the main task list**
+
+Find the task list render area and prepend the overdue section:
+
+```tsx
+{overdueTasks.length > 0 && (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+    {/* Section header */}
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <span style={{ fontSize: '10px', fontWeight: 700, color: '#F59E0B', textTransform: 'uppercase', letterSpacing: '1.5px' }}>
+        ⚠ Overdue
+      </span>
+      <div style={{ flex: 1, height: '1px', background: 'rgba(245,158,11,0.25)' }} />
+      <span style={{ fontSize: '10px', color: '#BBC9CD' }}>{overdueTasks.length} carried over</span>
+    </div>
+
+    {/* Overdue task cards */}
+    {overdueTasks.map(task => (
+      <div
+        key={task.id}
+        style={{
+          display: 'flex', alignItems: 'center', gap: '12px',
+          padding: '12px 14px', background: '#1A1A1A', borderRadius: '10px',
+          borderLeft: '3px solid #F59E0B',   // amber always, regardless of urgency
+        }}
+      >
+        {/* Checkbox */}
+        <input
+          type="checkbox"
+          checked={task.status === 'completed'}
+          onChange={() => taskService.toggleTaskStatus(task.id, task.status).then(fetchTasks)}
+          style={{ accentColor: '#F59E0B', width: '18px', height: '18px', cursor: 'pointer' }}
+        />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+            <span style={{ fontSize: '14px', color: '#DAE2FD' }}>{task.title}</span>
+            {/* overdue pill */}
+            <span style={{ fontSize: '10px', fontWeight: 600, color: '#F59E0B', background: 'rgba(245,158,11,0.15)', borderRadius: '4px', padding: '1px 6px' }}>
+              overdue
+            </span>
+            {/* urgency badge */}
+            <span style={urgencyBadgeStyle(task.urgency ?? 'medium')}>
+              {(task.urgency ?? 'medium').toUpperCase()}
+            </span>
+          </div>
+          <div style={{ fontSize: '11px', color: '#BBC9CD', marginTop: '3px' }}>
+            {formatRelativeDate(task.date)}
+            {task.description && ` · ${task.description}`}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '6px', flexShrink: 0 }}>
+          {/* Edit — reuse the same edit mechanism as today's tasks (toggle showEditForm or similar) */}
+          <button
+            onClick={() => { /* trigger edit for task.id — same handler as today's task cards */ }}
+            style={{ fontSize: '10px', color: '#BBC9CD', background: '#0D0D0D', border: '1px solid #333', borderRadius: '6px', padding: '4px 8px', cursor: 'pointer' }}
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => taskService.deleteTask(task.id).then(fetchTasks)}
+            style={{ fontSize: '10px', color: '#BBC9CD', background: '#0D0D0D', border: '1px solid #333', borderRadius: '6px', padding: '4px 8px', cursor: 'pointer' }}
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+    ))}
+  </div>
+)}
+```
+
+- [ ] **Step 6: Add `formatRelativeDate` helper**
+
+```typescript
+const formatRelativeDate = (dateStr: string): string => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const d = new Date(dateStr);
+  d.setHours(0, 0, 0, 0);
+  const diffDays = Math.round((today.getTime() - d.getTime()) / 86400000);
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays === 0) return 'Today';
+  return `${diffDays} days ago`;
+};
+```
+
+- [ ] **Step 7: Add Today section header above existing task list**
+
+```tsx
+{/* Today section label */}
+<div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+  <span style={{ fontSize: '10px', fontWeight: 700, color: '#00FFFF', textTransform: 'uppercase', letterSpacing: '1.5px' }}>
+    Today
+  </span>
+  <div style={{ flex: 1, height: '1px', background: 'rgba(0,255,255,0.15)' }} />
+</div>
+```
+
+- [ ] **Step 8: Sort today's tasks (completed last, then high→medium→low, then time)**
+
+Apply sort after fetching:
+
+```typescript
+const sortTasks = (tasks: Task[]): Task[] => {
+  const urgencyOrder = { high: 0, medium: 1, low: 2 };
+  return [...tasks].sort((a, b) => {
+    const aComplete = a.status === 'completed' ? 1 : 0;
+    const bComplete = b.status === 'completed' ? 1 : 0;
+    if (aComplete !== bComplete) return aComplete - bComplete;
+    const uDiff = urgencyOrder[a.urgency ?? 'low'] - urgencyOrder[b.urgency ?? 'low'];
+    if (uDiff !== 0) return uDiff;
+    if (a.time && b.time) return a.time.localeCompare(b.time);
+    return 0;
+  });
+};
+// Use: setTasks(sortTasks(todayData));
+```
+
+- [ ] **Step 9: Test manually — open the app and verify**
+
+```bash
+cd web && npm run dev
+```
+- Overdue section appears at top if any past-pending tasks exist
+- Urgency badges show on all task cards
+- Today section header shows below overdue
+- Completed tasks are dimmed and sorted to bottom
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/src/components/cyan/TaskDashboard.tsx
+git commit -m "feat(web): urgency display + overdue section in TaskDashboard"
+```
+
+---
+
+## Task 9: TaskDashboard — Today/Tomorrow Toggle + Voice Integration
+
+**Files:**
+- Modify: `web/src/components/cyan/TaskDashboard.tsx`
+
+- [ ] **Step 1: Add form state for urgency, taskDate, and voice**
+
+```typescript
+const [urgency, setUrgency] = useState<'high' | 'medium' | 'low'>('medium');
+const [taskDate, setTaskDate] = useState<'today' | 'tomorrow'>('today');
+```
+
+Remove the existing `formDuration` state if it's not needed in the new design (check if duration still appears in the form — if not, remove it).
+
+- [ ] **Step 2: Add date resolution helper**
+
+```typescript
+const resolveDate = (which: 'today' | 'tomorrow'): string => {
+  const d = new Date();
+  if (which === 'tomorrow') d.setDate(d.getDate() + 1);
+  return d.toISOString().split('T')[0];
+};
+```
+
+- [ ] **Step 3: Update `handleCreateTask` to pass urgency and resolved date**
+
+```typescript
+const handleCreateTask = async () => {
+  if (!formTitle.trim()) return;
+  setSubmitting(true);
+  try {
+    await taskService.createTask({
+      title: formTitle,
+      description: formDescription || null,
+      time: formTime || null,
+      urgency,
+      date: resolveDate(taskDate),
+      duration: null,
+    });
+    // Reset form
+    setFormTitle('');
+    setFormDescription('');
+    setFormTime('');
+    setUrgency('medium');
+    setTaskDate('today');
+    await fetchTasks();
+  } finally {
+    setSubmitting(false);
+  }
+};
+```
+
+- [ ] **Step 4: Add Today/Tomorrow toggle to the form**
+
+In the form JSX, add the toggle alongside the time input:
+
+```tsx
+{/* Time + Today/Tomorrow row */}
+<div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+  <input
+    value={formTime}
+    onChange={e => setFormTime(e.target.value)}
+    placeholder="Time (09:00)"
+    style={{ flex: 1, background: '#0D0D0D', border: '1px solid #2A2A2A', color: '#DAE2FD', borderRadius: '8px', padding: '8px 12px', fontSize: '13px', outline: 'none' }}
+  />
+  {/* Today / Tomorrow toggle */}
+  <div style={{ display: 'flex', background: '#0D0D0D', border: '1px solid #2A2A2A', borderRadius: '8px', overflow: 'hidden', flexShrink: 0 }}>
+    {(['today', 'tomorrow'] as const).map(opt => (
+      <button
+        key={opt}
+        onClick={() => setTaskDate(opt)}
+        style={{
+          padding: '6px 14px',
+          fontSize: '11px',
+          fontWeight: 700,
+          border: 'none',
+          cursor: 'pointer',
+          background: taskDate === opt ? 'linear-gradient(135deg, #0099CC, #00FFFF)' : 'transparent',
+          color: taskDate === opt ? '#000' : '#BBC9CD',
+        }}
+      >
+        {opt.charAt(0).toUpperCase() + opt.slice(1)}
+      </button>
+    ))}
+  </div>
+</div>
+```
+
+- [ ] **Step 5: Add urgency selector to the form**
+
+```tsx
+{/* Urgency selector */}
+<div style={{ display: 'flex', gap: '6px' }}>
+  {(['high', 'medium', 'low'] as const).map(level => {
+    const colors = {
+      high: { active: 'rgba(255,68,68,0.25)', border: 'rgba(255,68,68,0.6)', text: '#FF4444', inactiveBg: 'rgba(255,68,68,0.08)', inactiveBorder: 'rgba(255,68,68,0.25)' },
+      medium: { active: 'rgba(217,119,6,0.25)', border: 'rgba(217,119,6,0.6)', text: '#D97706', inactiveBg: 'rgba(217,119,6,0.08)', inactiveBorder: 'rgba(217,119,6,0.25)' },
+      low: { active: 'rgba(68,153,221,0.25)', border: 'rgba(68,153,221,0.6)', text: '#4499DD', inactiveBg: 'rgba(68,153,221,0.08)', inactiveBorder: 'rgba(68,153,221,0.25)' },
+    }[level];
+    const isActive = urgency === level;
+    return (
+      <button
+        key={level}
+        onClick={() => setUrgency(level)}
+        style={{
+          flex: 1,
+          padding: '7px 0',
+          borderRadius: '8px',
+          fontSize: '11px',
+          fontWeight: 700,
+          cursor: 'pointer',
+          border: `1px solid ${isActive ? colors.border : colors.inactiveBorder}`,
+          background: isActive ? colors.active : colors.inactiveBg,
+          color: colors.text,
+        }}
+      >
+        {level.toUpperCase()}
+      </button>
+    );
+  })}
+</div>
+```
+
+- [ ] **Step 6: Import VoiceTaskInput and wire it into the form**
+
+```typescript
+import VoiceTaskInput from './VoiceTaskInput';
+```
+
+In the form header area (where the add form title label is), add `VoiceTaskInput`:
+
+```tsx
+<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+  <span style={{ fontSize: '12px', fontWeight: 600, color: '#BBC9CD', textTransform: 'uppercase', letterSpacing: '1px' }}>
+    Add Task
+  </span>
+  <VoiceTaskInput
+    onExtracted={(fields) => {
+      if (fields.title) setFormTitle(fields.title);
+      if (fields.description) setFormDescription(fields.description);
+      if (fields.time) setFormTime(fields.time);
+      if (fields.urgency) setUrgency(fields.urgency);
+    }}
+  />
+</div>
+```
+
+- [ ] **Step 7: Manual verification**
+
+```bash
+cd web && npm run dev
+```
+Check:
+- [ ] Today/Tomorrow toggle appears in the form
+- [ ] Urgency buttons (HIGH / MED / LOW) appear and toggle correctly
+- [ ] Voice button appears; clicking starts recording (browser asks for mic permission)
+- [ ] After saying a task aloud and stopping, fields are pre-filled
+- [ ] Creating a task with "Tomorrow" shows it the next day, not today
+- [ ] Stats pills update after adding/completing tasks
+
+- [ ] **Step 8: Final build check**
+
+```bash
+cd web && npm run build && npm run lint
+```
+Expected: no errors or warnings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/components/cyan/TaskDashboard.tsx
+git commit -m "feat(web): Today/Tomorrow toggle + urgency form + voice integration in TaskDashboard"
+```
+
+---
+
+## Task 10: Deploy Backend + Wrap Up
+
+**Files:**
+- `backend/deploy.sh` (no changes needed)
+
+- [ ] **Step 1: Run all backend tests**
+
+```bash
+cd backend && source .venv/bin/activate
+pytest tests/ -v
+```
+Expected: all tests pass.
+
+- [ ] **Step 2: Deploy backend to Cloud Run**
+
+```bash
+bash backend/deploy.sh
+```
+
+- [ ] **Step 3: Smoke test voice parsing on production**
+
+With the web app pointed at the production backend, open the task page, click Voice, speak a task, and verify the form fills correctly.
+
+- [ ] **Step 4: Final commit + push**
+
+```bash
+git push origin staging
+```
+
+---
+
+## Summary
+
+| Task | What it produces |
+|------|-----------------|
+| 1 — DB Migration | `urgency` column live in Supabase |
+| 2 — Shared Auth | `auth.ts` extracted, `aiService.ts` updated |
+| 3 — Backend Schemas | `urgency` in create/update, `VoiceParse` models |
+| 4 — parse-voice Endpoint | `POST /tasks/parse-voice` with tests |
+| 5 — Frontend Types | `Task.urgency` + `TaskFormFields` |
+| 6 — taskService | `getOverdueTasks`, urgency in CRUD, `parseVoiceTranscript` |
+| 7 — VoiceTaskInput | Self-contained voice→fields component |
+| 8 — Dashboard: Urgency + Overdue | Coloured borders, badges, overdue section |
+| 9 — Dashboard: Form + Voice | Toggle, urgency selector, voice integration |
+| 10 — Deploy | Production live |

--- a/docs/superpowers/specs/2026-03-23-task-dashboard-redesign.md
+++ b/docs/superpowers/specs/2026-03-23-task-dashboard-redesign.md
@@ -1,0 +1,176 @@
+# Task Dashboard Redesign — Design Spec
+**Date:** 2026-03-23
+**Status:** Approved
+
+---
+
+## Overview
+
+Redesign the existing `TaskDashboard` to become a fully-featured daily to-do list with urgency levels, overdue task carry-forward, voice-to-task input, and next-day scheduling. The visual style must match the rest of the SuperCyan app (OLED dark, `#00FFFF` cyan, inline Tailwind hex classes, `GlassCard` containers).
+
+---
+
+## Decisions Log
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Urgency levels | 3 levels: **High / Medium / Low** |
+| 2 | Overdue style | Amber badge inline (same list, amber left border + "overdue" pill) |
+| 3 | Architecture | Approach B — enhance `TaskDashboard` + extract `VoiceTaskInput` component |
+| 4 | Voice → task confirmation | Pre-fill form for user review before saving |
+| 5 | Next-day scheduling | Today / Tomorrow toggle in add form |
+
+---
+
+## Features
+
+### 1. Urgency Levels
+
+Three levels, each with a distinct colour used on the left border of the task card, the urgency badge, and the form toggle button:
+
+| Level | Left border | Badge colour | Form button |
+|-------|------------|-------------|-------------|
+| High  | `#FF4444`  | Red         | Red outline |
+| Medium | `#F59E0B` | Amber       | Amber outline |
+| Low   | `#4499DD`  | Blue-grey   | Neutral border |
+
+Tasks are sorted within each date section: **High → Medium → Low**, then by scheduled time ascending. Completed tasks always sort to the bottom within their section, dimmed and struck through.
+
+### 2. Overdue Task Detection & Display
+
+A task is **overdue** when:
+- `status = 'pending'` AND
+- `date < today` (task date is in the past)
+
+Overdue tasks are fetched alongside today's tasks and rendered in a dedicated **"⚠ Overdue"** section at the top of the list, above the "Today" section. Each overdue task card:
+- Has an amber (`#F59E0B`) left border
+- Shows an **"overdue"** amber pill badge next to the title
+- Shows the original date as a relative label ("Yesterday", "2 days ago")
+- Still shows the urgency badge
+- Can be checked off, edited, or deleted like any other task
+
+The section header shows a count: "2 carried over". If there are no overdue tasks, the section is hidden entirely.
+
+**Daily refresh:** `pg_cron` already auto-archives tasks at midnight. Overdue detection is purely client-side: query tasks where `status = 'pending' AND date < today`.
+
+### 3. Today / Tomorrow Toggle
+
+The add-task form includes a segmented toggle defaulting to **Today**. Selecting **Tomorrow** sets the task date to `today + 1 day`. The active segment uses the cyan gradient; the inactive uses a neutral style. The toggle is visible in the form row alongside the time input.
+
+Voice-created tasks also respect this toggle — the extracted date from the transcript overrides it only if Qwen explicitly extracts a date; otherwise the toggle value is used.
+
+### 4. Voice-to-Task (VoiceTaskInput Component)
+
+A standalone `VoiceTaskInput.tsx` component handles the full voice flow:
+
+**Flow:**
+1. User clicks **🎤 Voice** button in the add-task form header
+2. Browser requests microphone permission (first use only)
+3. `MediaRecorder` records audio; `SpeechRecognition` (Web Speech API) transcribes in real-time, showing a live transcript preview
+4. User stops recording (button click or silence detection after 3s)
+5. Transcript is sent to the backend `/tasks/parse-voice` endpoint
+6. Qwen extracts structured fields: `title`, `description`, `urgency` (high/medium/low), `time` (HH:MM or null)
+7. Extracted fields pre-fill the add-task form — user reviews and confirms
+8. User clicks **+ Add Task** to save (standard form submit path — no separate voice-save route)
+
+**Component interface:**
+```typescript
+interface VoiceTaskInputProps {
+  onExtracted: (fields: Partial<TaskFormFields>) => void;
+}
+```
+
+**States:** idle → recording → processing → done (fields populated) / error
+
+**Error handling:**
+- Microphone denied → show inline error message
+- Qwen unavailable (503) → show "AI is warming up, try again in 30s"
+- Transcript empty → show "Nothing captured, try again"
+
+### 5. Backend: `/tasks/parse-voice` Endpoint
+
+New POST endpoint added to `endpoints.py`:
+
+**Request:**
+```json
+{ "transcript": "Call the accountant tomorrow morning at 9, it's quite important" }
+```
+
+**Response:**
+```json
+{
+  "title": "Call the accountant",
+  "description": null,
+  "urgency": "high",
+  "time": "09:00"
+}
+```
+
+Qwen is prompted with a structured extraction instruction. If a field cannot be confidently extracted it is returned as `null`. The frontend fills whatever is returned and leaves the rest for the user to complete.
+
+### 6. Database: `urgency` Column
+
+A new `urgency` column is added to the `tasks` table:
+
+```sql
+ALTER TABLE tasks ADD COLUMN urgency TEXT NOT NULL DEFAULT 'medium'
+  CHECK (urgency IN ('high', 'medium', 'low'));
+```
+
+Migration added to `/supabase/migrations/`.
+
+---
+
+## Component Architecture
+
+```
+TaskDashboard.tsx          (orchestrator — existing, enhanced)
+  ├── VoiceTaskInput.tsx   (new — voice recording + extraction)
+  └── taskService.ts       (enhanced — urgency field, overdue query)
+```
+
+### TaskDashboard changes
+- Add `urgency` to `Task` type and all form state
+- Add overdue detection: second Supabase query for `status=pending, date < today`
+- Add Today/Tomorrow toggle state (`taskDate: 'today' | 'tomorrow'`)
+- Render overdue section above today section
+- Urgency-based left border + badge on task cards
+- Sort tasks: completed last, then High → Medium → Low, then by time
+
+### VoiceTaskInput changes (new file)
+- `MediaRecorder` + `SpeechRecognition` for capture + live transcript
+- POST to `/tasks/parse-voice` with transcript
+- Calls `onExtracted(fields)` to populate parent form state
+
+### taskService changes
+- `getTasksForToday()` → also fetch overdue tasks (separate query or combined with date filter)
+- `createTask()` → pass `urgency` field
+- Add `parseVoiceTranscript(transcript: string)` calling the new backend endpoint
+
+---
+
+## Visual Spec
+
+| Element | Style |
+|---------|-------|
+| Overdue section header | `#F59E0B`, uppercase, `⚠` prefix, amber divider line |
+| Overdue card left border | `3px solid #F59E0B` |
+| Overdue badge | Amber pill: `color:#F59E0B; background:rgba(245,158,11,0.15)` |
+| High urgency border | `#FF4444` |
+| Medium urgency border | `#F59E0B` |
+| Low urgency border | `#4499DD` |
+| Completed card | `opacity: 0.5`, strikethrough title, filled cyan checkbox |
+| Today section header | `#00FFFF`, uppercase, cyan divider line |
+| Voice button | Cyan gradient, `🎤 Voice` label |
+| Today/Tomorrow toggle | Active segment: cyan gradient; inactive: `#BBC9CD` on `#0D0D0D` |
+| Urgency form buttons | Outlined, colour-matched per level; active state filled |
+
+---
+
+## Out of Scope (for this iteration)
+
+- Recurring tasks
+- Drag-to-reorder
+- Sub-tasks / checklists
+- Push notifications / reminders
+- Automatic voice submit (no human-in-loop) — revisit after stability confirmed

--- a/docs/superpowers/specs/2026-03-23-task-dashboard-redesign.md
+++ b/docs/superpowers/specs/2026-03-23-task-dashboard-redesign.md
@@ -31,8 +31,10 @@ Three levels, each with a distinct colour used on the left border of the task ca
 | Level | Left border | Badge colour | Form button |
 |-------|------------|-------------|-------------|
 | High  | `#FF4444`  | Red         | Red outline |
-| Medium | `#F59E0B` | Amber       | Amber outline |
+| Medium | `#D97706` | Warm amber  | Warm amber outline |
 | Low   | `#4499DD`  | Blue-grey   | Neutral border |
+
+> Note: Medium urgency uses `#D97706` (darker warm amber) rather than the bright `#F59E0B` used by the overdue section, so overdue and medium-urgency cards are visually distinguishable by left border colour.
 
 Tasks are sorted within each date section: **High → Medium → Low**, then by scheduled time ascending. Completed tasks always sort to the bottom within their section, dimmed and struck through.
 
@@ -43,21 +45,29 @@ A task is **overdue** when:
 - `date < today` (task date is in the past)
 
 Overdue tasks are fetched alongside today's tasks and rendered in a dedicated **"⚠ Overdue"** section at the top of the list, above the "Today" section. Each overdue task card:
-- Has an amber (`#F59E0B`) left border
+- Has an amber (`#F59E0B`) left border regardless of urgency (overdue styling takes precedence over urgency border colour)
+- Still shows the urgency pill badge (red/amber/blue) so urgency remains visible
 - Shows an **"overdue"** amber pill badge next to the title
 - Shows the original date as a relative label ("Yesterday", "2 days ago")
-- Still shows the urgency badge
 - Can be checked off, edited, or deleted like any other task
 
 The section header shows a count: "2 carried over". If there are no overdue tasks, the section is hidden entirely.
 
 **Daily refresh:** `pg_cron` already auto-archives tasks at midnight. Overdue detection is purely client-side: query tasks where `status = 'pending' AND date < today`.
 
+**RLS compatibility:** The existing RLS policy on `tasks` is `auth.uid() = user_id` with no date restriction. The date filter is applied at the Supabase query layer (`.eq('date', today)` in `getTasksForToday()`), not in the policy. `getOverdueTasks()` will apply `.lt('date', today)` at the query layer — this is fully compatible with the existing policy and will return all matching rows for the authenticated user.
+
+**Date handling:** The `tasks.date` column is a PostgreSQL `DATE` type. "Today" is resolved on the client as `new Date().toISOString().split('T')[0]` (a `YYYY-MM-DD` string). Supabase's JS client correctly serialises this string against a `DATE` column for both `.eq()` and `.lt()` comparisons. This is consistent with how `getTasksForToday()` already works.
+
 ### 3. Today / Tomorrow Toggle
 
 The add-task form includes a segmented toggle defaulting to **Today**. Selecting **Tomorrow** sets the task date to `today + 1 day`. The active segment uses the cyan gradient; the inactive uses a neutral style. The toggle is visible in the form row alongside the time input.
 
-Voice-created tasks also respect this toggle — the extracted date from the transcript overrides it only if Qwen explicitly extracts a date; otherwise the toggle value is used.
+The frontend resolves the actual date string (`YYYY-MM-DD`) from the toggle value before calling `createTask()`. The backend receives a resolved date string, not a "today/tomorrow" enum.
+
+Tasks scheduled for tomorrow simply appear in the "Today" section when tomorrow arrives — there is no separate "Upcoming" or "Tomorrow" section in the rendered view.
+
+Voice-created tasks respect the toggle by default. Qwen does not extract a date from the transcript — all tasks created via voice are assigned whichever date the toggle currently shows.
 
 ### 4. Voice-to-Task (VoiceTaskInput Component)
 
@@ -66,12 +76,23 @@ A standalone `VoiceTaskInput.tsx` component handles the full voice flow:
 **Flow:**
 1. User clicks **🎤 Voice** button in the add-task form header
 2. Browser requests microphone permission (first use only)
-3. `MediaRecorder` records audio; `SpeechRecognition` (Web Speech API) transcribes in real-time, showing a live transcript preview
-4. User stops recording (button click or silence detection after 3s)
-5. Transcript is sent to the backend `/tasks/parse-voice` endpoint
+3. `SpeechRecognition` (Web Speech API) transcribes in real-time, showing a live transcript preview. No `MediaRecorder` is needed — the text transcript is all that is sent to the backend; no audio blob is captured or stored.
+4. User manually stops recording by clicking the button again (no automatic silence detection — avoids truncating mid-sentence pauses)
+5. Transcript is sent to the backend `/tasks/parse-voice` endpoint with the user's auth token
 6. Qwen extracts structured fields: `title`, `description`, `urgency` (high/medium/low), `time` (HH:MM or null)
 7. Extracted fields pre-fill the add-task form — user reviews and confirms
 8. User clicks **+ Add Task** to save (standard form submit path — no separate voice-save route)
+
+**TaskFormFields type:**
+```typescript
+interface TaskFormFields {
+  title: string;
+  description: string | null;   // null if not provided
+  time: string | null;          // HH:MM or null
+  urgency: 'high' | 'medium' | 'low';
+  date: string;                 // YYYY-MM-DD, resolved from Today/Tomorrow toggle
+}
+```
 
 **Component interface:**
 ```typescript
@@ -86,10 +107,11 @@ interface VoiceTaskInputProps {
 - Microphone denied → show inline error message
 - Qwen unavailable (503) → show "AI is warming up, try again in 30s"
 - Transcript empty → show "Nothing captured, try again"
+- Malformed / non-JSON Qwen response → parse what fields are extractable; if `title` is absent or unparseable, show "Couldn't parse your task — please fill in manually" and leave the form empty for the user to type
 
 ### 5. Backend: `/tasks/parse-voice` Endpoint
 
-New POST endpoint added to `endpoints.py`:
+New POST endpoint added to `endpoints.py`. Requires authentication (Bearer token) — same as all other task endpoints.
 
 **Request:**
 ```json
@@ -106,9 +128,65 @@ New POST endpoint added to `endpoints.py`:
 }
 ```
 
-Qwen is prompted with a structured extraction instruction. If a field cannot be confidently extracted it is returned as `null`. The frontend fills whatever is returned and leaves the rest for the user to complete.
+The response **always includes all four keys**. Fields Qwen cannot confidently extract are returned as `null`. The frontend fills whatever is non-null and leaves the rest for the user to complete.
 
-### 6. Database: `urgency` Column
+**Auth:** The endpoint requires a valid Bearer token (same as all other task endpoints). `taskService.parseVoiceTranscript()` reads the Supabase session token using the same pattern as `aiService.ts`. However, `getAuthHeaders()` is currently defined locally inside `aiService.ts` and is not exported. As part of this work, extract it into a new shared utility file `web/src/services/auth.ts` and import it in both `aiService.ts` and `taskService.ts`. No token prop is needed in `VoiceTaskInputProps`; auth is handled inside the service layer.
+
+**Qwen system prompt (for the extraction call):**
+```
+You are a task extraction assistant. Given a voice transcript, extract the following fields in JSON:
+- title: short imperative task name (required, max 80 chars)
+- description: any extra detail beyond the title (null if none)
+- urgency: "high", "medium", or "low" based on these signals:
+    high — "urgent", "important", "asap", "critical", "can't wait", "must"
+    medium — "soon", "today", "need to", "should", implied time pressure
+    low — no urgency signals, "whenever", "eventually", "maybe"
+    default to "medium" if unclear
+- time: 24-hour HH:MM if a time is mentioned (null otherwise)
+
+Return only valid JSON, no explanation.
+```
+
+### 6. Backend: `updateTask` + Pydantic Schema Changes
+
+**`TaskCreateRequest`** must be extended to include `urgency`:
+```python
+class TaskCreateRequest(BaseModel):
+    title: str
+    description: Optional[str] = None
+    duration: Optional[int] = None
+    time: Optional[str] = None
+    date: Optional[str] = None
+    urgency: Optional[str] = None   # ADD THIS — "high" | "medium" | "low", defaults to "medium" in DB
+```
+
+**`TaskUpdateRequest`** must also be extended:
+```python
+class TaskUpdateRequest(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    duration: Optional[int] = None
+    time: Optional[str] = None
+    status: Optional[str] = None
+    is_archived: Optional[bool] = None
+    urgency: Optional[str] = None   # ADD THIS — "high" | "medium" | "low"
+```
+
+**`VoiceParseRequest` / `VoiceParseResponse`** — new Pydantic models added to `schemas.py`:
+```python
+class VoiceParseRequest(BaseModel):
+    transcript: str
+
+class VoiceParseResponse(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    urgency: Optional[str] = None   # "high" | "medium" | "low"
+    time: Optional[str] = None      # HH:MM or null
+```
+
+The `/tasks/parse-voice` endpoint uses these models for request validation and response serialisation — consistent with the project's convention of defining all schemas in `schemas.py`.
+
+### 7. Database: `urgency` Column
 
 A new `urgency` column is added to the `tasks` table:
 
@@ -117,7 +195,7 @@ ALTER TABLE tasks ADD COLUMN urgency TEXT NOT NULL DEFAULT 'medium'
   CHECK (urgency IN ('high', 'medium', 'low'));
 ```
 
-Migration added to `/supabase/migrations/`.
+The `DEFAULT 'medium'` ensures all existing rows are valid after migration — no backfill needed. Migration added to `/supabase/migrations/`.
 
 ---
 
@@ -126,26 +204,31 @@ Migration added to `/supabase/migrations/`.
 ```
 TaskDashboard.tsx          (orchestrator — existing, enhanced)
   ├── VoiceTaskInput.tsx   (new — voice recording + extraction)
-  └── taskService.ts       (enhanced — urgency field, overdue query)
+  └── taskService.ts       (enhanced — urgency field, overdue query, voice parse)
 ```
 
 ### TaskDashboard changes
 - Add `urgency` to `Task` type and all form state
 - Add overdue detection: second Supabase query for `status=pending, date < today`
-- Add Today/Tomorrow toggle state (`taskDate: 'today' | 'tomorrow'`)
+- Add Today/Tomorrow toggle state (`taskDate: 'today' | 'tomorrow'`), resolved to `YYYY-MM-DD` before `createTask()` call
 - Render overdue section above today section
-- Urgency-based left border + badge on task cards
+- Urgency-based left border + badge on task cards (overdue section uses amber border regardless)
 - Sort tasks: completed last, then High → Medium → Low, then by time
 
 ### VoiceTaskInput changes (new file)
-- `MediaRecorder` + `SpeechRecognition` for capture + live transcript
-- POST to `/tasks/parse-voice` with transcript
+- `SpeechRecognition` (Web Speech API) for live transcript — no `MediaRecorder`, no audio blob
+- Manual stop only (button click) — no silence detection
+- POST to `/tasks/parse-voice` with transcript and auth token
 - Calls `onExtracted(fields)` to populate parent form state
 
 ### taskService changes
-- `getTasksForToday()` → also fetch overdue tasks (separate query or combined with date filter)
-- `createTask()` → pass `urgency` field
-- Add `parseVoiceTranscript(transcript: string)` calling the new backend endpoint
+- `getTasksForToday()` — unchanged, continues to return `Task[]` for today's date
+- Add `getOverdueTasks(): Promise<Task[]>` — separate Supabase query: `status=pending, date < today`, ordered by date ascending (oldest first), then by urgency (high → medium → low), then by time ascending for same-date same-urgency ties
+- `createTask()` → accepts and passes `urgency` and resolved `date` fields
+- Add `parseVoiceTranscript(transcript: string): Promise<Partial<Omit<TaskFormFields, 'date'>>>` — POSTs to `/tasks/parse-voice` with auth headers read via shared `getAuthHeaders()` helper. The `date` field is always owned by the Today/Tomorrow toggle and is never returned from voice extraction.
+- Update `updateTask()` to accept and pass the `urgency` field so editing an existing task does not drop the urgency value
+
+`TaskDashboard` calls both `getTasksForToday()` and `getOverdueTasks()` in parallel on mount, storing results in separate state variables (`tasks` and `overdueTasks`).
 
 ---
 
@@ -154,15 +237,15 @@ TaskDashboard.tsx          (orchestrator — existing, enhanced)
 | Element | Style |
 |---------|-------|
 | Overdue section header | `#F59E0B`, uppercase, `⚠` prefix, amber divider line |
-| Overdue card left border | `3px solid #F59E0B` |
+| Overdue card left border | `3px solid #F59E0B` (always amber, regardless of urgency) |
 | Overdue badge | Amber pill: `color:#F59E0B; background:rgba(245,158,11,0.15)` |
-| High urgency border | `#FF4444` |
-| Medium urgency border | `#F59E0B` |
-| Low urgency border | `#4499DD` |
+| High urgency border (non-overdue) | `#FF4444` |
+| Medium urgency border (non-overdue) | `#D97706` |
+| Low urgency border (non-overdue) | `#4499DD` |
 | Completed card | `opacity: 0.5`, strikethrough title, filled cyan checkbox |
 | Today section header | `#00FFFF`, uppercase, cyan divider line |
 | Voice button | Cyan gradient, `🎤 Voice` label |
-| Today/Tomorrow toggle | Active segment: cyan gradient; inactive: `#BBC9CD` on `#0D0D0D` |
+| Today/Tomorrow toggle | Active segment: cyan gradient; inactive: `#BBC9CD` on `#0D0D0D` (`#BBC9CD` is the existing muted text colour used throughout `TaskDashboard` — not a one-off token) |
 | Urgency form buttons | Outlined, colour-matched per level; active state filled |
 
 ---
@@ -174,3 +257,4 @@ TaskDashboard.tsx          (orchestrator — existing, enhanced)
 - Sub-tasks / checklists
 - Push notifications / reminders
 - Automatic voice submit (no human-in-loop) — revisit after stability confirmed
+- Silence detection for auto-stop recording


### PR DESCRIPTION
## Summary
- Adds `EmbeddingScorer` service (`backend/app/services/scrapers/embedding_scorer.py`) that runs after each scrape run
- Concurrently embeds job descriptions via OpenAI `text-embedding-3-small` (semaphore=20) and computes cosine similarity against the user's primary CV embedding
- Updates `inbox_items.match_score`, `match_reasoning`, and `embedding` columns per job
- All 12 scrapers now capture and return inserted job IDs in the result dict
- `MultiSourceScraper` collects all job IDs post-gather and calls `EmbeddingScorer` as a post-scrape pass
- Full fallback: if no CV is uploaded or CV has no embedding, keyword scores stand — zero regression

## Cost
~\$0.002–\$0.024 per 200-job scrape (`text-embedding-3-small` at \$0.02/1M tokens)

## Test plan
- [x] All new `EmbeddingScorer` unit tests pass (cosine, early-exit, happy path, error resilience)
- [x] New `TestScraperReturnsJobIds` tests pass (job_ids in result dict, empty on duplicates)
- [x] New `TestMultiSourceScraperEmbedding` integration tests pass (scorer called with correct IDs, failure tolerance, skip on no IDs)
- [x] All pre-existing passing tests continue to pass (36 total)
- [ ] Upload a CV, trigger a scrape, verify `inbox_items.embedding IS NOT NULL` and `match_score` reflects semantic similarity
- [ ] Trigger a scrape with no CV — verify keyword scores unchanged, no errors logged

## Notes
- 2 pre-existing test failures (`test_partial_success_on_scraper_failure`, `test_match_score_never_null`) were failing before this branch and are not in scope
- Mr. Red to redeploy Cloud Run once this merges to staging