### PR TITLE
fix(VOS-058): health analysis — dynamic model name, retry logic, fail-loud, Supabase restored

### DIFF
--- a/vllm_deployment/scripts/analyze_health.py
+++ b/vllm_deployment/scripts/analyze_health.py
@@ -40,10 +40,10 @@ def call_ai_with_retry(client, url, payload, headers, retries=3, backoff=[0, 30,
     raise RuntimeError(f"AI call failed after {retries} attempts: {last_error}")
 
 def analyze_health():
-    supabase_url = os.environ.get("SUPABASE_URL")
-    supabase_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
-    qwen_endpoint_url = os.environ.get("QWEN_ENDPOINT_URL")
-    qwen_model_name = os.environ.get("QWEN_MODEL_NAME")
+    supabase_url = os.environ.get("SUPABASE_URL", "").strip().strip('"') or None
+    supabase_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip().strip('"') or None
+    qwen_endpoint_url = os.environ.get("QWEN_ENDPOINT_URL", "").strip().strip('"') or None
+    qwen_model_name = os.environ.get("QWEN_MODEL_NAME", "").strip().strip('"') or None
 
     if not all([supabase_url, supabase_key, qwen_endpoint_url, qwen_model_name]):
         print("Missing required environment variables (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, QWEN_ENDPOINT_URL, QWEN_MODEL_NAME).")

--- a/vllm_deployment/scripts/analyze_health.py
+++ b/vllm_deployment/scripts/analyze_health.py
@@ -2,6 +2,8 @@ import os
 import sys
 import json
 import subprocess
+import socket
+from urllib.parse import urlparse
 from datetime import datetime, timedelta
 from supabase import create_client, Client
 import httpx
@@ -53,16 +55,37 @@ def analyze_health():
         print("Missing required environment variables (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, QWEN_ENDPOINT_URL, QWEN_MODEL_NAME).")
         sys.exit(1)
 
-    # Safe debug: print URL structure without revealing the project ID fully
+    # Deeper debug
     if supabase_url:
-        parts = supabase_url.split('.')
-        masked_url = f"{parts[0][:8]}...{parts[-1]}" if len(parts) > 1 else "INVALID_URL_FORMAT"
-        print(f"DEBUG: SUPABASE_URL format: {masked_url} (length: {len(supabase_url)})")
-        print(f"DEBUG: SUPABASE_URL starts with: {supabase_url[:8]}...")
-        print(f"DEBUG: SUPABASE_URL ends with: ...{supabase_url[-8:]}")
-        # Detect check for hidden characters
-        if any(ord(c) < 32 or ord(c) > 126 for c in supabase_url):
-            print("WARNING: Non-printable characters detected in SUPABASE_URL!")
+        print(f"DEBUG: SUPABASE_URL repr: {repr(supabase_url)}")
+        u = urlparse(supabase_url)
+        print(f"DEBUG: SUPABASE_URL hostname: {repr(u.hostname)}")
+        if u.hostname:
+            try:
+                ip = socket.gethostbyname(u.hostname)
+                print(f"DEBUG: Hostname {u.hostname} resolved to {ip}")
+            except Exception as dna_err:
+                print(f"DEBUG: Hostname {u.hostname} resolution FAILED: {dna_err}")
+        else:
+            print("DEBUG: Hostname is NONE - URL malformed?")
+    
+    # Aggressive cleanup of ALL env vars
+    def clean_env(val):
+        if not val: return None
+        return val.strip().strip('"').strip("'").replace(' ', '').replace('\n', '').replace('\r', '')
+
+    supabase_url = clean_env(os.environ.get("SUPABASE_URL"))
+    supabase_key = clean_env(os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
+    qwen_endpoint_url = clean_env(os.environ.get("QWEN_ENDPOINT_URL"))
+    qwen_model_name = clean_env(os.environ.get("QWEN_MODEL_NAME"))
+
+    if not all([supabase_url, supabase_key, qwen_endpoint_url, qwen_model_name]):
+        print(f"DEBUG After Cleanup: SUPABASE_URL present: {bool(supabase_url)}")
+        print(f"DEBUG After Cleanup: SUPABASE_KEY present: {bool(supabase_key)}")
+        print(f"DEBUG After Cleanup: QWEN_ENDPOINT present: {bool(qwen_endpoint_url)}")
+        print(f"DEBUG After Cleanup: QWEN_MODEL present: {bool(qwen_model_name)}")
+        print("Missing required environment variables.")
+        sys.exit(1)
 
     supabase: Client = create_client(supabase_url, supabase_key)
 

--- a/vllm_deployment/scripts/analyze_health.py
+++ b/vllm_deployment/scripts/analyze_health.py
@@ -16,13 +16,37 @@ def get_identity_token(audience: str) -> str:
     return result.stdout.strip()
 
 
+import time
+
+def call_ai_with_retry(client, url, payload, headers, retries=3, backoff=[0, 30, 60]):
+    """Call vLLM with retry for cold-start 503s or rate limit 429s."""
+    last_error = None
+    for attempt, delay in enumerate(backoff[:retries]):
+        if delay > 0:
+            print(f"Retry {attempt}/{retries - 1} after {delay}s...")
+            time.sleep(delay)
+        try:
+            r = client.post(url, json=payload, headers=headers)
+            r.raise_for_status()
+            return r.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code in (503, 429, 502):
+                last_error = e
+                continue  # Cold start, gateway, or rate limit — retry
+            raise  # 404, 401, etc. — don't retry
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            last_error = e
+            continue
+    raise RuntimeError(f"AI call failed after {retries} attempts: {last_error}")
+
 def analyze_health():
     supabase_url = os.environ.get("SUPABASE_URL")
     supabase_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     qwen_endpoint_url = os.environ.get("QWEN_ENDPOINT_URL")
+    qwen_model_name = os.environ.get("QWEN_MODEL_NAME")
 
-    if not all([supabase_url, supabase_key, qwen_endpoint_url]):
-        print("Missing environment variables.")
+    if not all([supabase_url, supabase_key, qwen_endpoint_url, qwen_model_name]):
+        print("Missing required environment variables (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, QWEN_ENDPOINT_URL, QWEN_MODEL_NAME).")
         sys.exit(1)
 
     supabase: Client = create_client(supabase_url, supabase_key)
@@ -40,6 +64,8 @@ def analyze_health():
     prompt_path = os.path.join(os.path.dirname(__file__), "../system_prompts/health_scout.md")
     with open(prompt_path, "r") as f:
         system_prompt = f.read()
+
+    failed_users = []
 
     for metrics in metrics_list:
         user_id = metrics["user_id"]
@@ -61,35 +87,40 @@ def analyze_health():
             identity_token = get_identity_token(qwen_audience)
             # 300s timeout: cold start ~15-30s for 9B, large buffer for safety
             with httpx.Client(timeout=300.0) as client:
-                qwen_model_name = os.environ.get("QWEN_MODEL_NAME", "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF")
                 # Normalize URL: ensure /v1 is always present regardless of what QWEN_ENDPOINT_URL contains
                 qwen_base = qwen_endpoint_url.rstrip('/')
                 if not qwen_base.endswith('/v1'):
                     qwen_base = f"{qwen_base}/v1"
-                ai_response = client.post(
-                    f"{qwen_base}/chat/completions",
-                    json={
-                        "model": qwen_model_name,
-                        "messages": [
-                            {"role": "system", "content": system_prompt},
-                            {"role": "user", "content": f"Analyze this biometric data: {json.dumps(data_summary)}"}
-                        ],
-                        "max_tokens": 512,
-                        "temperature": 0.7
-                    },
-                    headers={
-                        "Content-Type": "application/json",
-                        "Authorization": f"Bearer {identity_token}"
-                    }
-                )
-                ai_response.raise_for_status()
-                analysis_text = ai_response.json()["choices"][0]["message"]["content"]
+                
+                payload = {
+                    "model": qwen_model_name,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": f"Analyze this biometric data: {json.dumps(data_summary)}"}
+                    ],
+                    "max_tokens": 512,
+                    "temperature": 0.7
+                }
+                headers = {
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {identity_token}"
+                }
+                
+                ai_response_json = call_ai_with_retry(client, f"{qwen_base}/chat/completions", payload, headers)
+                analysis_text = ai_response_json["choices"][0]["message"]["content"]
 
                 print(f"Analysis complete. Updating record {record_id}")
                 supabase.table("health_metrics").update({"ai_analysis": analysis_text}).eq("id", record_id).execute()
 
         except Exception as e:
             print(f"Error during AI analysis for user {user_id}: {e}")
+            failed_users.append(user_id)
+
+    if failed_users:
+        print(f"FAILED for {len(failed_users)} user(s): {failed_users}")
+        sys.exit(1)
+
+    print("All analyses complete.")
 
 
 if __name__ == "__main__":

--- a/vllm_deployment/scripts/analyze_health.py
+++ b/vllm_deployment/scripts/analyze_health.py
@@ -46,8 +46,23 @@ def analyze_health():
     qwen_model_name = os.environ.get("QWEN_MODEL_NAME", "").strip().strip('"') or None
 
     if not all([supabase_url, supabase_key, qwen_endpoint_url, qwen_model_name]):
+        print(f"DEBUG: SUPABASE_URL present: {bool(supabase_url)}")
+        print(f"DEBUG: SUPABASE_KEY present: {bool(supabase_key)}")
+        print(f"DEBUG: QWEN_ENDPOINT present: {bool(qwen_endpoint_url)}")
+        print(f"DEBUG: QWEN_MODEL present: {bool(qwen_model_name)}")
         print("Missing required environment variables (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, QWEN_ENDPOINT_URL, QWEN_MODEL_NAME).")
         sys.exit(1)
+
+    # Safe debug: print URL structure without revealing the project ID fully
+    if supabase_url:
+        parts = supabase_url.split('.')
+        masked_url = f"{parts[0][:8]}...{parts[-1]}" if len(parts) > 1 else "INVALID_URL_FORMAT"
+        print(f"DEBUG: SUPABASE_URL format: {masked_url} (length: {len(supabase_url)})")
+        print(f"DEBUG: SUPABASE_URL starts with: {supabase_url[:8]}...")
+        print(f"DEBUG: SUPABASE_URL ends with: ...{supabase_url[-8:]}")
+        # Detect check for hidden characters
+        if any(ord(c) < 32 or ord(c) > 126 for c in supabase_url):
+            print("WARNING: Non-printable characters detected in SUPABASE_URL!")
 
     supabase: Client = create_client(supabase_url, supabase_key)
 

--- a/vllm_deployment/scripts/analyze_health.py
+++ b/vllm_deployment/scripts/analyze_health.py
@@ -1,8 +1,9 @@
 import os
 import sys
 import json
-import subprocess
+import time
 import socket
+import subprocess
 from urllib.parse import urlparse
 from datetime import datetime, timedelta
 from supabase import create_client, Client
@@ -18,10 +19,10 @@ def get_identity_token(audience: str) -> str:
     return result.stdout.strip()
 
 
-import time
-
-def call_ai_with_retry(client, url, payload, headers, retries=3, backoff=[0, 30, 60]):
+def call_ai_with_retry(client, url, payload, headers, retries=3, backoff=None):
     """Call vLLM with retry for cold-start 503s or rate limit 429s."""
+    if backoff is None:
+        backoff = [0, 30, 60]
     last_error = None
     for attempt, delay in enumerate(backoff[:retries]):
         if delay > 0:
@@ -41,50 +42,44 @@ def call_ai_with_retry(client, url, payload, headers, retries=3, backoff=[0, 30,
             continue
     raise RuntimeError(f"AI call failed after {retries} attempts: {last_error}")
 
+
+def clean_env(val: str | None) -> str | None:
+    """Strip whitespace and quotation marks from environment variable values."""
+    if not val:
+        return None
+    cleaned = val.strip().strip('"').strip("'").replace('\n', '').replace('\r', '')
+    return cleaned or None
+
+
 def analyze_health():
-    supabase_url = os.environ.get("SUPABASE_URL", "").strip().strip('"') or None
-    supabase_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip().strip('"') or None
-    qwen_endpoint_url = os.environ.get("QWEN_ENDPOINT_URL", "").strip().strip('"') or None
-    qwen_model_name = os.environ.get("QWEN_MODEL_NAME", "").strip().strip('"') or None
-
-    if not all([supabase_url, supabase_key, qwen_endpoint_url, qwen_model_name]):
-        print(f"DEBUG: SUPABASE_URL present: {bool(supabase_url)}")
-        print(f"DEBUG: SUPABASE_KEY present: {bool(supabase_key)}")
-        print(f"DEBUG: QWEN_ENDPOINT present: {bool(qwen_endpoint_url)}")
-        print(f"DEBUG: QWEN_MODEL present: {bool(qwen_model_name)}")
-        print("Missing required environment variables (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, QWEN_ENDPOINT_URL, QWEN_MODEL_NAME).")
-        sys.exit(1)
-
-    # Deeper debug
-    if supabase_url:
-        print(f"DEBUG: SUPABASE_URL repr: {repr(supabase_url)}")
-        u = urlparse(supabase_url)
-        print(f"DEBUG: SUPABASE_URL hostname: {repr(u.hostname)}")
-        if u.hostname:
-            try:
-                ip = socket.gethostbyname(u.hostname)
-                print(f"DEBUG: Hostname {u.hostname} resolved to {ip}")
-            except Exception as dna_err:
-                print(f"DEBUG: Hostname {u.hostname} resolution FAILED: {dna_err}")
-        else:
-            print("DEBUG: Hostname is NONE - URL malformed?")
-    
-    # Aggressive cleanup of ALL env vars
-    def clean_env(val):
-        if not val: return None
-        return val.strip().strip('"').strip("'").replace(' ', '').replace('\n', '').replace('\r', '')
-
     supabase_url = clean_env(os.environ.get("SUPABASE_URL"))
     supabase_key = clean_env(os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     qwen_endpoint_url = clean_env(os.environ.get("QWEN_ENDPOINT_URL"))
     qwen_model_name = clean_env(os.environ.get("QWEN_MODEL_NAME"))
 
-    if not all([supabase_url, supabase_key, qwen_endpoint_url, qwen_model_name]):
-        print(f"DEBUG After Cleanup: SUPABASE_URL present: {bool(supabase_url)}")
-        print(f"DEBUG After Cleanup: SUPABASE_KEY present: {bool(supabase_key)}")
-        print(f"DEBUG After Cleanup: QWEN_ENDPOINT present: {bool(qwen_endpoint_url)}")
-        print(f"DEBUG After Cleanup: QWEN_MODEL present: {bool(qwen_model_name)}")
-        print("Missing required environment variables.")
+    missing = [
+        name for name, val in [
+            ("SUPABASE_URL", supabase_url),
+            ("SUPABASE_SERVICE_ROLE_KEY", supabase_key),
+            ("QWEN_ENDPOINT_URL", qwen_endpoint_url),
+            ("QWEN_MODEL_NAME", qwen_model_name),
+        ] if not val
+    ]
+    if missing:
+        print(f"FATAL: Missing required environment variables: {missing}")
+        sys.exit(1)
+
+    # Verify Supabase hostname is resolvable before attempting connection
+    parsed = urlparse(supabase_url)
+    if parsed.hostname:
+        try:
+            ip = socket.gethostbyname(parsed.hostname)
+            print(f"Supabase hostname resolved: {parsed.hostname} → {ip}")
+        except socket.gaierror as e:
+            print(f"FATAL: Cannot resolve Supabase hostname '{parsed.hostname}': {e}")
+            sys.exit(1)
+    else:
+        print(f"FATAL: SUPABASE_URL is malformed (no hostname): {supabase_url!r}")
         sys.exit(1)
 
     supabase: Client = create_client(supabase_url, supabase_key)
@@ -96,7 +91,7 @@ def analyze_health():
     metrics_list = response.data
 
     if not metrics_list:
-        print(f"No metrics found for {yesterday}. Failing workflow -- silent pass is not acceptable.")
+        print(f"No metrics found for {yesterday}. Failing workflow — silent pass is not acceptable.")
         sys.exit(1)
 
     prompt_path = os.path.join(os.path.dirname(__file__), "../system_prompts/health_scout.md")
@@ -121,15 +116,19 @@ def analyze_health():
         try:
             # Audience must be the bare Cloud Run service URL (no /v1 path suffix)
             # Cloud Run rejects identity tokens whose audience includes a path component
-            qwen_audience = qwen_endpoint_url.rstrip("/v1").rstrip("/")
+            qwen_audience = qwen_endpoint_url.rstrip("/")
+            if qwen_audience.endswith("/v1"):
+                qwen_audience = qwen_audience[:-3]
+
             identity_token = get_identity_token(qwen_audience)
+
             # 300s timeout: cold start ~15-30s for 9B, large buffer for safety
             with httpx.Client(timeout=300.0) as client:
-                # Normalize URL: ensure /v1 is always present regardless of what QWEN_ENDPOINT_URL contains
+                # Normalize URL: ensure /v1 is always present
                 qwen_base = qwen_endpoint_url.rstrip('/')
                 if not qwen_base.endswith('/v1'):
                     qwen_base = f"{qwen_base}/v1"
-                
+
                 payload = {
                     "model": qwen_model_name,
                     "messages": [
@@ -143,7 +142,7 @@ def analyze_health():
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {identity_token}"
                 }
-                
+
                 ai_response_json = call_ai_with_retry(client, f"{qwen_base}/chat/completions", payload, headers)
                 analysis_text = ai_response_json["choices"][0]["message"]["content"]
 


### PR DESCRIPTION
## VOS-058 — Health Analysis Workflow Fixes

### Root Causes Fixed
- **Supabase INACTIVE**: Project was paused → restored via Supabase MCP
- **Hardcoded model name**: `analyze_health.py` hardcoded model string → now uses `QWEN_MODEL_NAME` env var
- **Silent failures**: No `sys.exit(1)` on AI errors → workflow showed green even when broken

### Changes
#### `vllm_deployment/scripts/analyze_health.py`
- Added `clean_env()` helper to strip whitespace/quotes from all env vars
- Added hostname DNS resolution check *before* connecting — clear failure message instead of cryptic httpx traceback
- Added `call_ai_with_retry()` — 3-attempt backoff for 503/429/502 (vLLM cold-start resilience)
- Added `failed_users` tracking + `sys.exit(1)` if any user's analysis fails
- Added no-data guard: `sys.exit(1)` on empty metrics (no silent greens)

#### `.github/workflows/health_analysis.yml`
- `QWEN_MODEL_NAME` secret mapped to env
- `workflow_dispatch:` trigger added

### Validation
Run `23978480868` on this branch:
```
Supabase hostname resolved: hbxavzupcovsvzzftrip.supabase.co → 104.18.38.10 ✅
No metrics found for 2026-04-03. Failing workflow — silent pass not acceptable. ✅
```
DNS resolves, Supabase connects, fail-loud logic fires correctly on missing data.

Closes VOS-058