### PR TITLE
fix: safe JSONB merge for Google OAuth token writes (#119)

### DIFF
--- a/backend/app/api/v1/endpoints.py
+++ b/backend/app/api/v1/endpoints.py
@@ -525,16 +525,20 @@ async def google_callback(
 
     expiry_iso = creds.expiry.isoformat() if creds.expiry else None
 
-    # Store tokens in users.oauth_tokens.google (service role key client)
+    # Store tokens in users.oauth_tokens.google (service role key client).
+    # Use read-merge-write to preserve other provider tokens (e.g. Spotify).
+    tokens_row = email_service.supabase.table("users") \
+        .select("oauth_tokens") \
+        .eq("id", user_id).single().execute()
+    current_tokens = tokens_row.data.get("oauth_tokens") or {}
+    current_tokens["google"] = {
+        "access_token": creds.token,
+        "refresh_token": creds.refresh_token,
+        "token_expiry": expiry_iso,
+        "scopes": list(creds.scopes) if creds.scopes else GOOGLE_SCOPES,
+    }
     email_service.supabase.table("users").update({
-        "oauth_tokens": {
-            "google": {
-                "access_token": creds.token,
-                "refresh_token": creds.refresh_token,
-                "token_expiry": expiry_iso,
-                "scopes": list(creds.scopes) if creds.scopes else GOOGLE_SCOPES,
-            }
-        }
+        "oauth_tokens": current_tokens
     }).eq("id", user_id).execute()
 
     # Clear the one-time CSRF state from settings

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -215,11 +215,13 @@ class EmailService:
 
             return filtered_emails
         except Exception as e:
-            # Surface token failures clearly — 401 usually means stale/revoked credentials
+            # Surface token failures clearly — catch RefreshError explicitly and also
+            # inspect the message for 401 / invalid_grant signals from other layers.
+            from google.auth.exceptions import RefreshError
             err_str = str(e)
-            if "401" in err_str or "unauthorized" in err_str.lower() or "invalid_grant" in err_str.lower():
+            if isinstance(e, RefreshError) or "401" in err_str or "unauthorized" in err_str.lower() or "invalid_grant" in err_str.lower():
                 logger.warning(
-                    "[EmailService] Gmail API returned 401 for user %s — token likely expired or revoked: %s",
+                    "[EmailService] Gmail credential failure for user %s — token likely expired or revoked: %s",
                     user_id,
                     err_str,
                 )

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,5 +1,6 @@
 import os
 import time
+import logging
 from typing import List, Dict, Optional
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -7,6 +8,8 @@ from supabase import create_client, Client
 from pydantic import BaseModel
 from email.mime.text import MIMEText
 import base64
+
+logger = logging.getLogger(__name__)
 
 class EmailItem(BaseModel):
     id: str
@@ -115,19 +118,29 @@ class EmailService:
         return creds
 
     def _save_google_tokens(self, user_id: str, creds: Credentials) -> None:
-        """Persist refreshed Google credentials back to users.oauth_tokens."""
+        """Persist refreshed Google credentials back to users.oauth_tokens.google.
+
+        Uses a read-merge-write pattern to avoid overwriting other provider
+        tokens (e.g. Spotify) stored in the same oauth_tokens JSONB column.
+        """
         if not self.supabase:
             return
         expiry_iso = creds.expiry.isoformat() if creds.expiry else None
+
+        # Fetch current oauth_tokens to preserve other provider keys
+        row = self.supabase.table("users") \
+            .select("oauth_tokens") \
+            .eq("id", user_id).single().execute()
+        current_tokens = row.data.get("oauth_tokens") or {}
+
+        current_tokens["google"] = {
+            "access_token": creds.token,
+            "refresh_token": creds.refresh_token,
+            "token_expiry": expiry_iso,
+            "scopes": list(creds.scopes) if creds.scopes else [],
+        }
         self.supabase.table("users").update({
-            "oauth_tokens": {
-                "google": {
-                    "access_token": creds.token,
-                    "refresh_token": creds.refresh_token,
-                    "token_expiry": expiry_iso,
-                    "scopes": list(creds.scopes) if creds.scopes else [],
-                }
-            }
+            "oauth_tokens": current_tokens
         }).eq("id", user_id).execute()
 
     async def fetch_inbox(self, user_id: str) -> List[Dict]:
@@ -202,8 +215,16 @@ class EmailService:
 
             return filtered_emails
         except Exception as e:
-            # Rule 11: Error Handling for external APIs
-            print(f"Error fetching Gmail: {e}")
+            # Surface token failures clearly — 401 usually means stale/revoked credentials
+            err_str = str(e)
+            if "401" in err_str or "unauthorized" in err_str.lower() or "invalid_grant" in err_str.lower():
+                logger.warning(
+                    "[EmailService] Gmail API returned 401 for user %s — token likely expired or revoked: %s",
+                    user_id,
+                    err_str,
+                )
+            else:
+                logger.error("[EmailService] Error fetching Gmail for user %s: %s", user_id, err_str)
             return []
 
     async def get_contacts(self, user_id: str, query: str) -> List[Dict]:

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -1,0 +1,113 @@
+# backend/tests/test_email_service.py
+"""Unit tests for EmailService — VOS-119 fixes.
+
+Tests:
+  - Spotify tokens are preserved when _save_google_tokens writes back to oauth_tokens.
+  - get_user_gmail_credentials handles NULL oauth_tokens without crashing.
+
+No real Supabase or Google API calls are made.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+
+class TestSaveGoogleTokensPreservesSpotify(unittest.TestCase):
+    """_save_google_tokens must merge, not overwrite, oauth_tokens."""
+
+    def _make_service(self, stored_oauth_tokens: dict):
+        """Return an EmailService with a mocked Supabase client."""
+        with patch.dict("os.environ", {
+            "SUPABASE_URL": "https://fake.supabase.co",
+            "SUPABASE_SERVICE_ROLE_KEY": "fake-key",
+        }):
+            with patch("app.services.email_service.create_client") as mock_create:
+                mock_supabase = MagicMock()
+                mock_create.return_value = mock_supabase
+
+                from app.services.email_service import EmailService
+                svc = EmailService()
+                svc.supabase = mock_supabase
+
+        # Stub the read side: returns stored_oauth_tokens
+        select_chain = MagicMock()
+        select_chain.single.return_value.execute.return_value.data = {
+            "oauth_tokens": stored_oauth_tokens
+        }
+        mock_supabase.table.return_value.select.return_value.eq.return_value = select_chain
+
+        # Stub the write side: capture the value that was written
+        update_chain = MagicMock()
+        mock_supabase.table.return_value.update.return_value.eq.return_value = update_chain
+
+        return svc, mock_supabase
+
+    def test_spotify_tokens_preserved(self):
+        """Writing refreshed Google creds must leave spotify key intact."""
+        existing_tokens = {
+            "google": {
+                "access_token": "old-google-token",
+                "refresh_token": "google-refresh",
+                "token_expiry": None,
+                "scopes": [],
+            },
+            "spotify": {
+                "access_token": "spotify-access",
+                "refresh_token": "spotify-refresh",
+                "expires_at": 9999999999,
+                "provider": "spotify",
+            },
+        }
+        svc, mock_supabase = self._make_service(existing_tokens)
+
+        # Build a minimal fake Credentials object
+        from unittest.mock import PropertyMock
+        fake_creds = MagicMock()
+        fake_creds.token = "new-google-token"
+        fake_creds.refresh_token = "google-refresh"
+        fake_creds.expiry = datetime(2026, 12, 31, tzinfo=timezone.utc)
+        type(fake_creds).scopes = PropertyMock(return_value=["https://mail.googleapis.com/"])
+
+        svc._save_google_tokens("user-123", fake_creds)
+
+        # Capture what was passed to update()
+        call_args = mock_supabase.table.return_value.update.call_args
+        written = call_args[0][0]["oauth_tokens"]
+
+        self.assertIn("spotify", written, "spotify key must survive the write")
+        self.assertEqual(written["spotify"], existing_tokens["spotify"])
+        self.assertEqual(written["google"]["access_token"], "new-google-token")
+
+    def test_null_oauth_tokens_does_not_crash(self):
+        """When oauth_tokens is NULL in the DB, _save_google_tokens must not raise."""
+        svc, mock_supabase = self._make_service(stored_oauth_tokens=None)
+
+        # Stub read to return None for oauth_tokens (simulates DB NULL)
+        select_chain = MagicMock()
+        select_chain.single.return_value.execute.return_value.data = {
+            "oauth_tokens": None
+        }
+        mock_supabase.table.return_value.select.return_value.eq.return_value = select_chain
+
+        from unittest.mock import PropertyMock
+        fake_creds = MagicMock()
+        fake_creds.token = "new-token"
+        fake_creds.refresh_token = "refresh"
+        fake_creds.expiry = None
+        type(fake_creds).scopes = PropertyMock(return_value=None)
+
+        # Should not raise
+        try:
+            svc._save_google_tokens("user-456", fake_creds)
+        except Exception as exc:
+            self.fail(f"_save_google_tokens raised unexpectedly: {exc}")
+
+        call_args = mock_supabase.table.return_value.update.call_args
+        written = call_args[0][0]["oauth_tokens"]
+        # google key must be present; no spotify key (was NULL)
+        self.assertIn("google", written)
+        self.assertNotIn("spotify", written)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `_save_google_tokens` in `email_service.py` was doing a destructive overwrite of the entire `oauth_tokens` JSONB column, destroying Spotify and other provider tokens on every Gmail token refresh
- The Google OAuth callback in `endpoints.py` had the same destructive pattern on initial connect
- Both now use a **read-merge-write** pattern: fetch current `oauth_tokens`, update only the `google` key, write back the full object
- Added `logging.warning` on 401/unauthorized errors from the Gmail API to surface token expiry and revocation clearly in logs

## Test plan

- [ ] Connect Gmail — verify `oauth_tokens` contains `{ google: {...} }`
- [ ] Connect Spotify — verify `oauth_tokens` contains both `google` and `spotify` keys
- [ ] Trigger a Gmail token refresh (e.g. let the access token expire) — verify Spotify key is still present in `oauth_tokens` after refresh
- [ ] Revoke Gmail access and re-authenticate — verify Spotify tokens are preserved
- [ ] Check logs for `[EmailService] Gmail API returned 401` warning when credentials are stale