### PR TITLE
feat: Calendar UI component and dashboard text scaling (#121, #122)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -18,6 +18,7 @@
         "expo-blur": "~15.0.8",
         "expo-linear-gradient": "~15.0.8",
         "expo-navigation-bar": "3.0.7",
+        "expo-notifications": "~0.29.0",
         "expo-status-bar": "~3.0.9",
         "lucide-react-native": "^0.577.0",
         "react": "19.1.0",
@@ -2128,6 +2129,108 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -2450,6 +2553,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -3989,6 +4102,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -4005,6 +4131,30 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -4382,6 +4532,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4641,13 +4797,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -4661,8 +4833,6 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -5063,6 +5233,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
@@ -5221,6 +5400,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -5228,6 +5424,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/depd": {
@@ -5357,8 +5570,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -5367,6 +5578,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5487,8 +5704,6 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5498,8 +5713,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5509,8 +5722,6 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -5835,6 +6046,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-6.0.2.tgz",
+      "integrity": "sha512-qcj6kGq3mc7x5yIb5KxESurFTJCoEKwNEL34RdPEvTB/xhl7SeVZlu05sZBqxB1V4Ryzq/LsCb7NHNfBbb3L7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-blur": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-15.0.8.tgz",
@@ -5844,6 +6064,284 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-constants": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.8.tgz",
+      "integrity": "sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~10.0.11",
+        "@expo/env": "~0.4.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/config": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-10.0.11.tgz",
+      "integrity": "sha512-nociJ4zr/NmbVfMNe9j/+zRlt7wz/siISu7PjdWE4WE+elEGxWWxsGzltdJG0llzrM+khx8qUiFK5aiVcdMBww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/config-types": "^52.0.5",
+        "@expo/json-file": "^9.0.2",
+        "deepmerge": "^4.3.1",
+        "getenv": "^1.0.0",
+        "glob": "^10.4.2",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "3.35.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/config-plugins": {
+      "version": "9.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.17.tgz",
+      "integrity": "sha512-m24F1COquwOm7PBl5wRbkT9P9DviCXe0D7S7nQsolfbhdCWuvMkfXeoWmgjtdhy7sDlOyIgBrAdnB6MfsWKqIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^52.0.5",
+        "@expo/json-file": "~9.0.2",
+        "@expo/plist": "^0.2.2",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^1.0.0",
+        "glob": "^10.4.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/config-plugins/node_modules/@expo/json-file": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.0.2.tgz",
+      "integrity": "sha512-yAznIUrybOIWp3Uax7yRflB0xsEpvIwIEqIjao9SGi2Gaa+N0OamWfe0fnXBSWF+2zzF4VvqwT4W5zwelchfgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/config-types": {
+      "version": "52.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-52.0.5.tgz",
+      "integrity": "sha512-AMDeuDLHXXqd8W+0zSjIt7f37vUd/BP8p43k68NHpyAvQO+z8mbQZm3cNQVAMySeayK2XoPigAFB1JF2NFajaA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-constants/node_modules/@expo/env": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-0.4.2.tgz",
+      "integrity": "sha512-TgbCgvSk0Kq0e2fLoqHwEBL4M0ztFjnBEz0YCDm5boc1nvkV1VMuIMteVdeBwnTh8Z0oPJTwHCD49vhMEt1I6A==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^1.0.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/json-file": {
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.1.5.tgz",
+      "integrity": "sha512-prWBhLUlmcQtvN6Y7BpW2k9zXGd3ySa3R6rAguMJkp1z22nunLN64KYTUWfijFlprFoxm9r2VNnGkcbndAlgKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/plist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.2.2.tgz",
+      "integrity": "sha512-ZZGvTO6vEWq02UAPs3LIdja+HRO18+LRI5QuDl6Hs3Ps7KX7xU6Y6kjahWKY37Rx2YjNpX07dGpBFzzC+vKa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.7",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version has critical issues, please update to the latest version",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/expo-constants/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/expo-constants/node_modules/getenv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
+      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expo-constants/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-constants/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/expo-constants/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-constants/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-constants/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-constants/node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/expo-constants/node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/expo-constants/node_modules/xmlbuilder": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
+      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/expo-linear-gradient": {
@@ -5904,6 +6402,110 @@
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.85.tgz",
       "integrity": "sha512-pcE4i0X7y3hsAE0SpIl7t6dUc0B0NZLd1yv7ssm4FrLhWG+CGyIq4eFDXpmPU1XHmL5PPySxTAjEMiwv6tAmOw==",
       "license": "MIT"
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.29.14",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.29.14.tgz",
+      "integrity": "sha512-AVduNx9mKOgcAqBfrXS1OHC9VAQZrDQLbVbcorMjPDGXW7m0Q5Q+BG6FYM/saVviF2eO8fhQRsTT40yYv5/bhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.6.5",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~6.0.2",
+        "expo-constants": "~17.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/image-utils": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.6.5.tgz",
+      "integrity": "sha512-RsS/1CwJYzccvlprYktD42KjyfWZECH6PPIEowvoSmXfGLfdViwcUEI4RvBfKX5Jli6P67H+6YmHvPTbGOboew==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.0.0",
+        "fs-extra": "9.0.0",
+        "getenv": "^1.0.0",
+        "jimp-compact": "0.16.1",
+        "parse-png": "^2.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "temp-dir": "~2.0.0",
+        "unique-string": "~2.0.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/fs-extra": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/getenv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
+      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/expo-server": {
       "version": "1.0.5",
@@ -6551,6 +7153,49 @@
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/freeport-async": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz",
@@ -6614,6 +7259,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6637,8 +7291,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -6672,8 +7324,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -6789,8 +7439,6 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6813,13 +7461,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -7064,11 +7737,39 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -7119,6 +7820,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7143,6 +7863,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7150,6 +7886,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -7164,6 +7918,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -7221,6 +7990,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest-environment-node": {
@@ -8215,8 +8999,6 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -8873,6 +9655,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -9098,6 +9925,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9275,6 +10108,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -10135,6 +10977,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -10276,6 +11135,23 @@
       "license": "ISC",
       "optional": true,
       "peer": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -10666,7 +11542,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -10813,6 +11717,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/terminal-link": {
@@ -11151,6 +12064,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -11227,6 +12152,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -11355,6 +12293,27 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wonka": {
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
@@ -11372,6 +12331,24 @@
       }
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/mobile/src/components/MobileCard.jsx
+++ b/mobile/src/components/MobileCard.jsx
@@ -1,22 +1,22 @@
 import React from 'react';
-import { StyleSheet, View, TouchableOpacity, Platform } from 'react-native';
+import { StyleSheet, View, TouchableOpacity } from 'react-native';
 import { BlurView } from 'expo-blur';
-import { palette } from '../theme';
+import { theme } from '../theme';
 
 /**
  * MobileCard - A "glassmorphism" card component matching the SuperCyan design system.
  * Uses semi-transparent background and blur on iOS/Android (via expo-blur).
  */
-export const MobileCard = ({ children, style, onClick, className }) => {
+export const MobileCard = ({ children, style, onClick }) => {
   const Container = onClick ? TouchableOpacity : View;
-  
+
   return (
-    <Container 
-      onPress={onClick} 
+    <Container
+      onPress={onClick}
       activeOpacity={onClick ? 0.9 : 1}
       style={[styles.root, style]}
     >
-      <BlurView intensity={30} tint="dark" style={StyleSheet.absoluteFill} />
+      <BlurView intensity={35} tint="dark" style={StyleSheet.absoluteFill} />
       {children}
     </Container>
   );
@@ -24,17 +24,16 @@ export const MobileCard = ({ children, style, onClick, className }) => {
 
 const styles = StyleSheet.create({
   root: {
-    borderRadius: 20,
+    borderRadius: theme.radii.lg,
     overflow: 'hidden',
-    backgroundColor: 'rgba(26, 26, 26, 0.8)',
+    backgroundColor: theme.colors.bgCard,
     borderWidth: 1,
-    borderColor: 'rgba(0, 255, 255, 0.2)',
-    padding: 16,
-    // Premium cyan glow
-    shadowColor: '#00FFFF',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.08,
-    shadowRadius: 15,
-    elevation: 6,
+    borderColor: theme.colors.borderColor,
+    padding: theme.spacing.md,
+    shadowColor: theme.colors.glow,
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.2,
+    shadowRadius: 24,
+    elevation: 8,
   },
 });

--- a/mobile/src/components/MobileHeader.jsx
+++ b/mobile/src/components/MobileHeader.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { StyleSheet, View, TouchableOpacity, Platform } from 'react-native';
 import { Text } from './Themed';
 import { Menu, Search, Bell, ArrowLeft } from 'lucide-react-native';
-import { palette } from '../theme';
+import { theme } from '../theme';
 import { MobileMenu } from './MobileMenu';
 import { BlurView } from 'expo-blur';
 
@@ -17,11 +17,11 @@ export const MobileHeader = ({ title, subtitle, showBack, onBack }) => {
             <View style={styles.leftSection}>
               {showBack ? (
                 <TouchableOpacity onPress={onBack} style={styles.iconButton}>
-                  <ArrowLeft size={24} color={palette.accentPrimary} />
+                  <ArrowLeft size={24} color={theme.colors.accentPrimary} />
                 </TouchableOpacity>
               ) : (
                 <TouchableOpacity onPress={() => setMenuOpen(true)} style={styles.iconButton}>
-                  <Menu size={24} color={palette.accentPrimary} />
+                  <Menu size={24} color={theme.colors.accentPrimary} />
                 </TouchableOpacity>
               )}
               <View>
@@ -31,11 +31,11 @@ export const MobileHeader = ({ title, subtitle, showBack, onBack }) => {
             </View>
             
             <View style={styles.rightSection}>
-              <TouchableOpacity style={styles.iconButtonSmall}>
-                <Search size={20} color={palette.textSecondary} />
-              </TouchableOpacity>
-              <TouchableOpacity style={styles.iconButtonSmallRelative}>
-                <Bell size={20} color={palette.textSecondary} />
+                <TouchableOpacity style={styles.iconButtonSmall}>
+                  <Search size={20} color={theme.colors.textSecondary} />
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.iconButtonSmallRelative}>
+                  <Bell size={20} color={theme.colors.textSecondary} />
                 <View style={styles.notificationDot} />
               </TouchableOpacity>
             </View>
@@ -50,15 +50,15 @@ export const MobileHeader = ({ title, subtitle, showBack, onBack }) => {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: 'rgba(26,26,26,0.95)',
+    backgroundColor: theme.colors.bgSecondary,
     zIndex: 30,
     borderBottomWidth: 1,
-    borderBottomColor: 'rgba(0, 255, 255, 0.2)',
-    shadowColor: '#00FFFF',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 20,
-    elevation: 5,
+    borderBottomColor: theme.colors.borderColor,
+    shadowColor: theme.colors.glow,
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.25,
+    shadowRadius: 26,
+    elevation: 8,
   },
   blurContainer: {
     flexGrow: 1,
@@ -77,17 +77,18 @@ const styles = StyleSheet.create({
   },
   iconButton: {
     padding: 8,
-    backgroundColor: 'rgba(10,10,10,0.5)',
-    borderRadius: 12,
+    backgroundColor: theme.colors.overlay,
+    borderRadius: theme.radii.sm,
   },
   title: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
+    fontSize: theme.typography.heading3,
+    fontWeight: '600',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
   },
   subtitle: {
-    fontSize: 12,
-    color: palette.textSecondary,
+    fontSize: theme.typography.caption,
+    color: theme.colors.textSecondary,
   },
   rightSection: {
     flexDirection: 'row',
@@ -96,13 +97,13 @@ const styles = StyleSheet.create({
   },
   iconButtonSmall: {
     padding: 8,
-    backgroundColor: 'rgba(10,10,10,0.5)',
-    borderRadius: 12,
+    backgroundColor: theme.colors.overlay,
+    borderRadius: theme.radii.sm,
   },
   iconButtonSmallRelative: {
     padding: 8,
-    backgroundColor: 'rgba(10,10,10,0.5)',
-    borderRadius: 12,
+    backgroundColor: theme.colors.overlay,
+    borderRadius: theme.radii.sm,
     position: 'relative',
   },
   notificationDot: {
@@ -111,9 +112,9 @@ const styles = StyleSheet.create({
     right: 4,
     width: 8,
     height: 8,
-    backgroundColor: '#EF4444',
+    backgroundColor: '#F97316',
     borderRadius: 4,
     borderWidth: 1,
-    borderColor: '#1A1A1A',
+    borderColor: theme.colors.bgSecondary,
   }
 });

--- a/mobile/src/components/MobileMenu.jsx
+++ b/mobile/src/components/MobileMenu.jsx
@@ -19,7 +19,7 @@ import {
   User
 } from 'lucide-react-native';
 import { Text } from './Themed';
-import { palette, spacing } from '../theme';
+import { spacing, theme } from '../theme';
 import { LinearGradient } from 'expo-linear-gradient';
 
 const { width } = Dimensions.get('window');
@@ -31,7 +31,7 @@ const MENU_ITEMS = [
   { icon: Newspaper, label: "News", path: "Feeds" },
   { icon: Heart, label: "Health", path: "Health" },
   { icon: Mail, label: "Email", path: "Mail" },
-  { icon: Calendar, label: "Calendar", path: "Plan" },
+  { icon: Calendar, label: "Planner", path: "Plan" },
   { icon: CheckSquare, label: "Todo List", path: "Plan" },
   { icon: Cpu, label: "AI Tools", path: "AI" },
   { icon: Zap, label: "Internet Speed", path: "Home" },
@@ -101,7 +101,7 @@ export function MobileMenu({ isOpen, onClose }) {
               <View style={styles.headerTop}>
                 <View style={styles.brandRow}>
                   <LinearGradient
-                    colors={['#00FFFF', '#0099CC']}
+                    colors={[theme.colors.accentPrimary, theme.colors.accentSecondary]}
                     style={styles.logoBox}
                   >
                     <Cpu size={24} color="#0A0A0A" />
@@ -112,13 +112,13 @@ export function MobileMenu({ isOpen, onClose }) {
                   </View>
                 </View>
                 <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
-                  <X size={24} color={palette.textSecondary} />
+                  <X size={24} color={theme.colors.textSecondary} />
                 </TouchableOpacity>
               </View>
 
               <View style={styles.profileCard}>
                 <LinearGradient
-                  colors={['#00FFFF', '#0099CC']}
+                  colors={[theme.colors.accentPrimary, theme.colors.accentSecondary]}
                   style={styles.avatarBox}
                 >
                   <User size={20} color="#0A0A0A" />
@@ -144,7 +144,10 @@ export function MobileMenu({ isOpen, onClose }) {
                     style={[styles.menuItem, isActive && styles.menuItemActive]}
                     onPress={() => handleNavigate(item.path)}
                   >
-                    <Icon size={20} color={isActive ? palette.accentPrimary : palette.textSecondary} />
+                    <Icon
+                      size={20}
+                      color={isActive ? theme.colors.accentPrimary : theme.colors.textSecondary}
+                    />
                     <Text style={[styles.menuItemText, isActive && styles.menuItemTextActive]}>
                       {item.label}
                     </Text>
@@ -155,7 +158,7 @@ export function MobileMenu({ isOpen, onClose }) {
 
             <View style={styles.footer}>
               <TouchableOpacity style={styles.menuItem}>
-                <Settings size={20} color={palette.textSecondary} />
+                <Settings size={20} color={theme.colors.textSecondary} />
                 <Text style={styles.menuItemText}>Settings</Text>
               </TouchableOpacity>
             </View>
@@ -182,14 +185,14 @@ const styles = StyleSheet.create({
     left: 0,
     width: '85%',
     maxWidth: 320,
-    backgroundColor: 'rgba(26,26,26,0.98)',
+    backgroundColor: theme.colors.bgSecondary,
     borderRightWidth: 1,
-    borderRightColor: 'rgba(0, 255, 255, 0.2)',
-    shadowColor: '#00FFFF',
+    borderRightColor: theme.colors.borderColor,
+    shadowColor: theme.colors.glow,
     shadowOffset: { width: 4, height: 0 },
-    shadowOpacity: 0.15,
-    shadowRadius: 20,
-    elevation: 10,
+    shadowOpacity: 0.2,
+    shadowRadius: 28,
+    elevation: 12,
   },
   blurView: {
     flex: 1,
@@ -198,7 +201,7 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     paddingTop: Platform.OS === 'ios' ? 60 : spacing.xl,
     borderBottomWidth: 1,
-    borderBottomColor: 'rgba(0, 255, 255, 0.2)',
+    borderBottomColor: theme.colors.borderColor,
   },
   headerTop: {
     flexDirection: 'row',
@@ -219,28 +222,29 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   brandTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#FFF',
+    fontSize: theme.typography.heading3,
+    fontWeight: '600',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
   },
   brandSubtitle: {
-    fontSize: 12,
-    color: palette.textSecondary,
+    fontSize: theme.typography.caption,
+    color: theme.colors.textSecondary,
   },
   closeBtn: {
     padding: 8,
-    backgroundColor: 'rgba(10,10,10,0.5)',
-    borderRadius: 12,
+    backgroundColor: theme.colors.overlay,
+    borderRadius: theme.radii.sm,
   },
   profileCard: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 12,
     padding: 12,
-    backgroundColor: 'rgba(10,10,10,0.5)',
+    backgroundColor: theme.colors.overlay,
     borderWidth: 1,
-    borderColor: 'rgba(0, 255, 255, 0.2)',
-    borderRadius: 16,
+    borderColor: theme.colors.borderColor,
+    borderRadius: theme.radii.md,
   },
   avatarBox: {
     width: 40,
@@ -250,13 +254,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   profileName: {
-    fontSize: 14,
+    fontSize: theme.typography.body,
     fontWeight: '600',
-    color: '#FFF',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
   },
   profileType: {
-    fontSize: 12,
-    color: palette.textSecondary,
+    fontSize: theme.typography.caption,
+    color: theme.colors.textSecondary,
   },
   scrollArea: {
     flex: 1,
@@ -271,24 +276,24 @@ const styles = StyleSheet.create({
     gap: 12,
     paddingHorizontal: 16,
     paddingVertical: 12,
-    borderRadius: 12,
+    borderRadius: theme.radii.sm,
   },
   menuItemActive: {
     backgroundColor: 'rgba(0, 255, 255, 0.1)',
   },
   menuItemText: {
-    fontSize: 16,
+    fontSize: theme.typography.body,
     fontWeight: '600',
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
   },
   menuItemTextActive: {
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
   },
   footer: {
     padding: spacing.md,
     borderTopWidth: 1,
-    borderTopColor: 'rgba(0, 255, 255, 0.2)',
-    backgroundColor: 'rgba(26,26,26,0.95)',
+    borderTopColor: theme.colors.borderColor,
+    backgroundColor: theme.colors.bgSecondary,
     paddingBottom: Platform.OS === 'ios' ? 40 : spacing.md,
   },
 });

--- a/mobile/src/components/Themed.tsx
+++ b/mobile/src/components/Themed.tsx
@@ -6,7 +6,20 @@ export type ViewProps = DefaultView['props'];
 
 export function Text(props: TextProps) {
   const { style, ...otherProps } = props;
-  return <DefaultText style={[{ color: theme.colors.textPrimary, fontFamily: 'System' }, style]} {...otherProps} />;
+  return (
+    <DefaultText
+      style={[
+        {
+          color: theme.colors.textPrimary,
+          fontFamily: theme.fonts.body,
+          fontSize: theme.typography.body,
+          lineHeight: theme.typography.body * 1.4,
+        },
+        style,
+      ]}
+      {...otherProps}
+    />
+  );
 }
 
 export function View(props: ViewProps) {
@@ -17,18 +30,23 @@ export function View(props: ViewProps) {
 export function Card(props: ViewProps) {
   const { style, ...otherProps } = props;
   return (
-    <DefaultView 
+    <DefaultView
       style={[
-        { 
-          backgroundColor: theme.colors.bgCard, 
-          borderRadius: 12, 
+        {
+          backgroundColor: theme.colors.bgCard,
+          borderRadius: theme.radii.md,
           padding: theme.spacing.md,
           borderWidth: 1,
-          borderColor: theme.colors.borderColor
-        }, 
-        style
-      ]} 
-      {...otherProps} 
+          borderColor: theme.colors.borderColor,
+          shadowColor: theme.colors.glow,
+          shadowOffset: { width: 0, height: 6 },
+          shadowOpacity: 0.16,
+          shadowRadius: 22,
+          elevation: 7,
+        },
+        style,
+      ]}
+      {...otherProps}
     />
   );
 }
@@ -40,16 +58,19 @@ export const commonStyles = StyleSheet.create({
     padding: theme.spacing.md,
   },
   title: {
-    fontSize: 24,
-    fontWeight: 'bold',
+    fontSize: theme.typography.heading2,
+    fontWeight: '600',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
     marginBottom: theme.spacing.md,
   },
   subtitle: {
-    fontSize: 16,
-    color: theme.colors.textMuted,
+    fontSize: theme.typography.caption,
+    color: theme.colors.textSecondary,
     marginBottom: theme.spacing.sm,
   },
   accentText: {
     color: theme.colors.accentPrimary,
-  }
+    fontFamily: theme.fonts.heading,
+  },
 });

--- a/mobile/src/screens/ChatScreen.jsx
+++ b/mobile/src/screens/ChatScreen.jsx
@@ -8,7 +8,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import Markdown from 'react-native-markdown-display';
-import { palette, spacing } from '../theme';
+import { spacing, theme } from '../theme';
 import { sendChat, fetchVllmStatus, triggerVllmWarmup } from '../services/api';
 import { MobileHeader } from '../components/MobileHeader';
 import { MobileCard } from '../components/MobileCard';
@@ -28,11 +28,16 @@ const AI_TOOLS = [
 ];
 
 const markdownStyles = {
-  body: { color: '#FFF', fontSize: 14, lineHeight: 22 },
-  code_inline: { backgroundColor: 'rgba(0, 212, 255, 0.1)', color: palette.accentPrimary, borderRadius: 4, paddingHorizontal: 4 },
+  body: { color: theme.colors.textPrimary, fontSize: 15, lineHeight: 24 },
+  paragraph: { marginTop: 0, marginBottom: 10 },
+  heading1: { color: theme.colors.textPrimary, fontSize: 22, marginBottom: 10 },
+  heading2: { color: theme.colors.textPrimary, fontSize: 20, marginBottom: 8 },
+  heading3: { color: theme.colors.textPrimary, fontSize: 18, marginBottom: 6 },
+  bullet_list: { marginBottom: 8 },
+  code_inline: { backgroundColor: 'rgba(0, 212, 255, 0.1)', color: theme.colors.accentPrimary, borderRadius: 4, paddingHorizontal: 4 },
   code_block: { backgroundColor: '#000', borderWidth: 1, borderColor: 'rgba(255, 255, 255, 0.1)', borderRadius: 12, padding: 12, marginVertical: 8 },
   fence: { backgroundColor: '#000', borderWidth: 1, borderColor: 'rgba(255, 255, 255, 0.1)', borderRadius: 12, padding: 12, marginVertical: 8 },
-  link: { color: palette.accentPrimary, textDecorationLine: 'underline' },
+  link: { color: theme.colors.accentPrimary, textDecorationLine: 'underline' },
 };
 
 export default function ChatScreen() {
@@ -153,7 +158,7 @@ export default function ChatScreen() {
 
           {loading && (
             <View style={styles.typingContainer}>
-              <ActivityIndicator size="small" color={palette.accentPrimary} />
+              <ActivityIndicator size="small" color={theme.colors.accentPrimary} />
               <Text style={styles.typingText}>AI is thinking...</Text>
             </View>
           )}
@@ -162,7 +167,7 @@ export default function ChatScreen() {
              <TextInput
                style={styles.input}
                placeholder="Message Qwen..."
-               placeholderTextColor={palette.textMuted}
+               placeholderTextColor={theme.colors.textMuted}
                value={input}
                onChangeText={setInput}
                multiline
@@ -176,7 +181,7 @@ export default function ChatScreen() {
                   colors={['rgba(0, 212, 255, 0.4)', 'rgba(0, 153, 204, 0.4)']}
                   style={styles.sendButtonGradient}
                 >
-                  <ArrowUp size={20} color={palette.accentPrimary}  />
+                  <ArrowUp size={20} color={theme.colors.accentPrimary}  />
                 </LinearGradient>
              </TouchableOpacity>
           </BlurView>
@@ -190,7 +195,6 @@ export default function ChatScreen() {
       <MobileHeader title="AI Tools" subtitle="AI Orchestration Hub" />
       
       <ScrollView contentContainerStyle={styles.scrollContainer}>
-        {/* AI Assistant Status Card */}
         <TouchableOpacity 
           onPress={() => setView('chat')}
           activeOpacity={0.9}
@@ -253,7 +257,7 @@ export default function ChatScreen() {
                       <Text style={styles.toolName}>{tool.name}</Text>
                       <Text style={styles.toolDesc}>{tool.description}</Text>
                    </View>
-                   <ChevronRight size={20} color={palette.accentPrimary}  />
+                   <ChevronRight size={20} color={theme.colors.accentPrimary}  />
                 </View>
              </MobileCard>
            ))}
@@ -266,7 +270,7 @@ export default function ChatScreen() {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: palette.bgPrimary,
+    backgroundColor: theme.colors.bgPrimary,
   },
   scrollContainer: {
     padding: spacing.md,
@@ -297,9 +301,10 @@ const styles = StyleSheet.create({
     shadowRadius: 10,
   },
   cpuTitle: {
-    fontSize: 20,
-    fontWeight: '900',
-    color: '#FFF',
+    fontSize: theme.typography.heading2,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
     letterSpacing: 0.5,
   },
   statusRow: {
@@ -327,7 +332,7 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0, 255, 255, 0.3)',
   },
   warmupText: {
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
     fontWeight: '900',
     fontSize: 11,
     letterSpacing: 1,
@@ -345,8 +350,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 255, 255, 0.4)',
   },
   sectionTitle: {
-    color: palette.textSecondary,
-    fontSize: 11,
+    color: theme.colors.textSecondary,
+    fontSize: theme.typography.caption,
     fontWeight: '900',
     textTransform: 'uppercase',
     letterSpacing: 2,
@@ -372,13 +377,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   toolName: {
-    fontSize: 17,
-    fontWeight: '800',
-    color: '#FFF',
+    fontSize: theme.typography.heading3,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
   },
   toolDesc: {
     fontSize: 13,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     marginTop: 2,
   },
   // Chat Styles
@@ -411,14 +417,14 @@ const styles = StyleSheet.create({
     borderRadius: 22,
   },
   bubbleUser: {
-    backgroundColor: palette.accentPrimary,
+    backgroundColor: theme.colors.accentPrimary,
     borderBottomRightRadius: 4,
   },
   bubbleAI: {
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    backgroundColor: theme.colors.overlay,
     borderBottomLeftRadius: 4,
     borderWidth: 1,
-    borderColor: 'rgba(0, 255, 255, 0.2)',
+    borderColor: theme.colors.borderColor,
   },
   bubbleTextUser: {
     color: '#000',
@@ -439,7 +445,7 @@ const styles = StyleSheet.create({
     marginTop: 100,
   },
   emptyText: {
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontSize: 15,
     marginTop: 16,
     fontWeight: '600',
@@ -453,7 +459,7 @@ const styles = StyleSheet.create({
   },
   typingText: {
     fontSize: 12,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontStyle: 'italic',
   },
   inputWrapper: {
@@ -469,7 +475,7 @@ const styles = StyleSheet.create({
   },
   input: {
     flex: 1,
-    color: '#FFF',
+    color: theme.colors.textPrimary,
     fontSize: 15,
     maxHeight: 120,
     paddingTop: 0,
@@ -487,4 +493,3 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0, 255, 255, 0.3)',
   },
 });
-

--- a/mobile/src/screens/DashboardScreen.jsx
+++ b/mobile/src/screens/DashboardScreen.jsx
@@ -3,7 +3,7 @@ import { View, StyleSheet, ScrollView, Dimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useNavigation } from '@react-navigation/native';
-import { palette, spacing } from '../theme';
+import { spacing, theme } from '../theme';
 import { MobileHeader } from '../components/MobileHeader';
 import { MobileCard } from '../components/MobileCard';
 import { Text } from '../components/Themed';
@@ -76,7 +76,7 @@ const MAIN_FEATURES = [
     iconColor: "#A855F7"
   },
   { 
-    title: "Calendar", 
+    title: "Planner", 
     Icon: Calendar, 
     description: "Schedule & events",
     count: "3 meetings today",
@@ -119,9 +119,8 @@ export default function DashboardScreen() {
   return (
     <SafeAreaView style={styles.root} edges={['top']}>
       <MobileHeader title="Super Cyan" subtitle="AI Orchestration Platform" />
-      
+
       <ScrollView contentContainerStyle={styles.scrollContainer} showsVerticalScrollIndicator={false}>
-        {/* Quick Stats Grid */}
         <View style={styles.statsGrid}>
           {QUICK_STATS.map((stat, idx) => {
             const IconComponent = stat.Icon;
@@ -145,7 +144,6 @@ export default function DashboardScreen() {
           })}
         </View>
 
-        {/* Section Header */}
         <View style={styles.sectionHeader}>
           <LinearGradient
             colors={['#00FFFF', 'transparent']}
@@ -156,7 +154,6 @@ export default function DashboardScreen() {
           <Text style={styles.sectionTitle}>QUICK ACCESS</Text>
         </View>
 
-        {/* Main Features Grid */}
         <View style={styles.featuresGrid}>
           {MAIN_FEATURES.map((feature, idx) => {
             const IconComponent = feature.Icon;
@@ -204,11 +201,11 @@ const STAT_CARD_WIDTH = (width - spacing.md * 2 - spacing.sm) / 2;
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: palette.bgPrimary,
+    backgroundColor: theme.colors.bgPrimary,
   },
   scrollContainer: {
     padding: spacing.md,
-    paddingBottom: 100, // Bottom padding for TabBar
+    paddingBottom: 100,
   },
   statsGrid: {
     flexDirection: 'row',
@@ -254,14 +251,15 @@ const styles = StyleSheet.create({
     color: '#4ADE80',
   },
   statValue: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: palette.textPrimary,
+    fontSize: theme.typography.heading2,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
     marginBottom: 4,
   },
   statLabel: {
-    fontSize: 12,
-    color: palette.textSecondary,
+    fontSize: theme.typography.caption,
+    color: theme.colors.textSecondary,
   },
   sectionHeader: {
     flexDirection: 'row',
@@ -275,9 +273,9 @@ const styles = StyleSheet.create({
     borderRadius: 2,
   },
   sectionTitle: {
-    fontSize: 12,
+    fontSize: theme.typography.caption,
     fontWeight: '600',
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     letterSpacing: 2,
   },
   featuresGrid: {
@@ -296,7 +294,7 @@ const styles = StyleSheet.create({
   featureIconContainer: {
     width: 56,
     height: 56,
-    borderRadius: 14,
+    borderRadius: theme.radii.sm,
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 1,
@@ -305,14 +303,15 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   featureTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: palette.textPrimary,
+    fontSize: theme.typography.heading3,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
     marginBottom: 4,
   },
   featureDesc: {
     fontSize: 14,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     marginBottom: 4,
   },
   featureCountRow: {
@@ -321,14 +320,14 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   featureCount: {
-    fontSize: 12,
+    fontSize: theme.typography.caption,
     fontWeight: '600',
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
   },
   featureChevron: {
     width: 32,
     height: 32,
-    borderRadius: 8,
+    borderRadius: theme.radii.sm,
     backgroundColor: 'rgba(0, 255, 255, 0.1)',
     alignItems: 'center',
     justifyContent: 'center',

--- a/mobile/src/screens/FeedsScreen.jsx
+++ b/mobile/src/screens/FeedsScreen.jsx
@@ -7,7 +7,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Text } from '../components/Themed';
-import { palette, spacing } from '../theme';
+import { spacing, theme } from '../theme';
 import { fetchTechFeeds, fetchConcerts } from '../services/api';
 import { MobileHeader } from '../components/MobileHeader';
 import { MobileCard } from '../components/MobileCard';
@@ -57,7 +57,7 @@ export default function FeedsScreen() {
           <Text style={styles.sourceText}>{item.source}</Text>
         </View>
         <TouchableOpacity style={styles.readMore}>
-          <ChevronRight size={16} color={palette.accentPrimary}  />
+          <ChevronRight size={16} color={theme.colors.accentPrimary} />
         </TouchableOpacity>
       </View>
     </MobileCard>
@@ -69,7 +69,7 @@ export default function FeedsScreen() {
         <View style={{ flex: 1 }}>
           <Text style={styles.artistName}>{item.artist}</Text>
           <View style={styles.locationRow}>
-            <MapPin size={12} color={palette.textMuted}  />
+            <MapPin size={12} color={theme.colors.textMuted} />
             <Text style={styles.locationText}>{item.venue}, {item.city}</Text>
           </View>
         </View>
@@ -80,7 +80,7 @@ export default function FeedsScreen() {
       
       <View style={styles.concertFooter}>
         <View style={styles.dateInfo}>
-          <Calendar size={14} color={palette.accentPrimary}  />
+          <Calendar size={14} color={theme.colors.accentPrimary} />
           <Text style={styles.dateText}>{item.date}</Text>
         </View>
         {item.ticket_url && (
@@ -104,9 +104,8 @@ export default function FeedsScreen() {
       
       <ScrollView
         contentContainerStyle={styles.scrollContainer}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={palette.accentPrimary} />}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.accentPrimary} />}
       >
-        {/* Tab Selector */}
         <View style={styles.tabBar}>
           <TouchableOpacity 
             onPress={() => setTab('tech')}
@@ -156,7 +155,7 @@ export default function FeedsScreen() {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: palette.bgPrimary,
+    backgroundColor: theme.colors.bgPrimary,
   },
   scrollContainer: {
     padding: spacing.md,
@@ -164,12 +163,12 @@ const styles = StyleSheet.create({
   },
   tabBar: {
     flexDirection: 'row',
-    backgroundColor: 'rgba(26, 26, 26, 0.8)',
-    borderRadius: 16,
+    backgroundColor: theme.colors.bgCard,
+    borderRadius: theme.radii.md,
     padding: 6,
     marginBottom: 24,
     borderWidth: 1,
-    borderColor: 'rgba(0, 255, 255, 0.1)',
+    borderColor: theme.colors.borderColor,
   },
   tab: {
     flex: 1,
@@ -185,11 +184,11 @@ const styles = StyleSheet.create({
   tabText: {
     fontSize: 13,
     fontWeight: '700',
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     letterSpacing: 0.5,
   },
   tabTextActive: {
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
     fontWeight: '900',
   },
   sectionHeader: {
@@ -205,8 +204,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 255, 255, 0.4)',
   },
   sectionTitle: {
-    color: palette.textSecondary,
-    fontSize: 11,
+    color: theme.colors.textSecondary,
+    fontSize: theme.typography.caption,
     fontWeight: '900',
     textTransform: 'uppercase',
     letterSpacing: 2,
@@ -233,20 +232,21 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0, 255, 255, 0.2)',
   },
   categoryText: {
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
     fontSize: 10,
     fontWeight: '900',
     letterSpacing: 1.2,
   },
   feedTime: {
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontSize: 11,
     fontWeight: '600',
   },
   feedTitle: {
-    fontSize: 18,
-    fontWeight: '800',
-    color: '#FFF',
+    fontSize: theme.typography.heading3,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
     lineHeight: 26,
     marginBottom: 16,
   },
@@ -265,14 +265,14 @@ const styles = StyleSheet.create({
     width: 6,
     height: 6,
     borderRadius: 3,
-    backgroundColor: palette.accentPrimary,
+    backgroundColor: theme.colors.accentPrimary,
     shadowColor: '#00FFFF',
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.8,
     shadowRadius: 4,
   },
   sourceText: {
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontSize: 13,
     fontWeight: '700',
   },
@@ -305,7 +305,7 @@ const styles = StyleSheet.create({
   },
   locationText: {
     fontSize: 14,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontWeight: '600',
   },
   genreBadge: {
@@ -350,7 +350,7 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0, 255, 255, 0.3)',
   },
   ticketText: {
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
     fontWeight: '900',
     fontSize: 13,
     letterSpacing: 0.5,
@@ -360,9 +360,8 @@ const styles = StyleSheet.create({
     paddingVertical: 60,
   },
   emptyText: {
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontSize: 15,
     fontWeight: '600',
   },
 });
-

--- a/mobile/src/screens/HealthScreen.jsx
+++ b/mobile/src/screens/HealthScreen.jsx
@@ -7,7 +7,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Text } from '../components/Themed';
-import { palette, spacing } from '../theme';
+import { spacing, theme } from '../theme';
 import { fetchHealth } from '../services/api';
 import { MobileHeader } from '../components/MobileHeader';
 import { MobileCard } from '../components/MobileCard';
@@ -42,7 +42,7 @@ export default function HealthScreen() {
   if (loading) {
     return (
       <View style={[styles.root, { justifyContent: 'center', alignItems: 'center' }]}>
-        <ActivityIndicator size="large" color={palette.accentPrimary} />
+        <ActivityIndicator size="large" color={theme.colors.accentPrimary} />
       </View>
     );
   }
@@ -53,7 +53,7 @@ export default function HealthScreen() {
       
       <ScrollView
         contentContainerStyle={styles.scrollContainer}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={palette.accentPrimary} />}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.accentPrimary} />}
       >
         <View style={styles.grid}>
           {healthStats.map((stat) => (
@@ -86,14 +86,14 @@ export default function HealthScreen() {
           />
           <View style={styles.analysisCover}>
              <View style={styles.analysisIconBox}>
-                <Moon size={28} color={palette.accentPrimary}  />
+                <Moon size={28} color={theme.colors.accentPrimary} />
              </View>
              <View style={{ flex: 1, marginLeft: 16 }}>
                 <Text style={styles.analysisTitle}>Sleep Analysis</Text>
                 <Text style={styles.analysisDesc}>Deep REM & recovery insights via Samsung Watch.</Text>
              </View>
              <TouchableOpacity style={styles.analysisButton}>
-                <ChevronRight size={18} color={palette.accentPrimary}  />
+                <ChevronRight size={18} color={theme.colors.accentPrimary} />
              </TouchableOpacity>
           </View>
         </MobileCard>
@@ -105,7 +105,7 @@ export default function HealthScreen() {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: palette.bgPrimary,
+    backgroundColor: theme.colors.bgPrimary,
   },
   scrollContainer: {
     padding: spacing.md,
@@ -139,18 +139,19 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   statValue: {
-    fontSize: 26,
-    fontWeight: '900',
-    color: '#FFF',
+    fontSize: theme.typography.heading2,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
   },
   statUnit: {
     fontSize: 12,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontWeight: '700',
   },
   statLabel: {
     fontSize: 11,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontWeight: '700',
     textTransform: 'uppercase',
     letterSpacing: 1,
@@ -169,8 +170,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 255, 255, 0.4)',
   },
   sectionTitle: {
-    color: palette.textSecondary,
-    fontSize: 11,
+    color: theme.colors.textSecondary,
+    fontSize: theme.typography.caption,
     fontWeight: '900',
     textTransform: 'uppercase',
     letterSpacing: 2,
@@ -196,13 +197,14 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0, 255, 255, 0.2)',
   },
   analysisTitle: {
-    fontSize: 18,
-    fontWeight: '800',
-    color: '#FFF',
+    fontSize: theme.typography.heading3,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
   },
   analysisDesc: {
     fontSize: 13,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     marginTop: 2,
     fontWeight: '600',
   },

--- a/mobile/src/screens/PlannerScreen.jsx
+++ b/mobile/src/screens/PlannerScreen.jsx
@@ -8,7 +8,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Text } from '../components/Themed';
-import { palette, spacing } from '../theme';
+import { spacing, theme } from '../theme';
 import { fetchTasks, createTask, updateTask } from '../services/api';
 import { MobileHeader } from '../components/MobileHeader';
 import { MobileCard } from '../components/MobileCard';
@@ -92,8 +92,9 @@ export default function PlannerScreen() {
 
   const renderTaskItem = (item) => {
     const done = item.status === 'completed';
-    const priorityColor = item.priority === 'high' ? '#FF5555' : 
-                         item.priority === 'medium' ? '#FFCC00' : '#00FFFF';
+    const priority = item.urgency || item.priority || 'medium';
+    const priorityColor = priority === 'high' ? '#FF5555' : 
+                         priority === 'medium' ? '#FFCC00' : '#00FFFF';
 
     return (
       <MobileCard 
@@ -116,12 +117,12 @@ export default function PlannerScreen() {
             <View style={styles.taskMeta}>
               <View style={[styles.priorityBadge, { backgroundColor: `${priorityColor}15`, borderColor: `${priorityColor}30` }]}>
                 <Text style={{ color: priorityColor, fontSize: 10, fontWeight: '900', textTransform: 'uppercase', letterSpacing: 1 }}>
-                  {item.priority || 'medium'}
+                  {priority}
                 </Text>
               </View>
               {item.time && (
                 <View style={styles.timeInfo}>
-                  <Clock size={14} color={palette.textSecondary}  />
+                  <Clock size={14} color={theme.colors.textSecondary} />
                   <Text style={styles.timeText}>{formatTime12h(item.time)}</Text>
                 </View>
               )}
@@ -139,13 +140,13 @@ export default function PlannerScreen() {
       <MobileCard key={item.id} style={styles.scheduleCard}>
         <View style={styles.scheduleContent}>
           <View style={styles.scheduleIcon}>
-            <Video size={20} color={palette.accentPrimary}  />
+            <Video size={20} color={theme.colors.accentPrimary} />
           </View>
           <View style={{ flex: 1, marginLeft: 12 }}>
-            <Text style={styles.scheduleTitle}>{item.title}</Text>
-            <View style={styles.scheduleMeta}>
-              <Clock size={14} color={palette.textMuted}  />
-              <Text style={styles.scheduleTime}>{formatTime12h(item.time)}</Text>
+              <Text style={styles.scheduleTitle}>{item.title}</Text>
+              <View style={styles.scheduleMeta}>
+                <Clock size={14} color={theme.colors.textMuted} />
+                <Text style={styles.scheduleTime}>{formatTime12h(item.time)}</Text>
               <Text style={styles.scheduleDot}>•</Text>
               <Text style={styles.scheduleDuration}>{item.duration || '30m'}</Text>
             </View>
@@ -164,12 +165,11 @@ export default function PlannerScreen() {
       
       <ScrollView
         contentContainerStyle={styles.scrollContainer}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={palette.accentPrimary} />}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.accentPrimary} />}
       >
-        {/* Stats Grid */}
         <View style={styles.statsGrid}>
           <MobileCard style={styles.statCard}>
-            <Text style={[styles.statValue, { color: palette.accentPrimary }]}>{pendingCount}</Text>
+            <Text style={[styles.statValue, { color: theme.colors.accentPrimary }]}>{pendingCount}</Text>
             <Text style={styles.statLabel}>Pending</Text>
           </MobileCard>
           <MobileCard style={styles.statCard}>
@@ -204,7 +204,7 @@ export default function PlannerScreen() {
             end={{ x: 1, y: 0 }}
             style={styles.addButtonGradient}
           >
-            <Plus size={24} color={palette.accentPrimary}  />
+            <Plus size={24} color={theme.colors.accentPrimary} />
             <Text style={styles.addButtonText}>Add New {activeTab === 'tasks' ? 'Task' : 'Event'}</Text>
           </LinearGradient>
         </TouchableOpacity>
@@ -259,7 +259,7 @@ export default function PlannerScreen() {
               <View style={styles.modalHeader}>
               <Text style={styles.modalTitle}>New Entry</Text>
               <TouchableOpacity onPress={() => setShowAddTask(false)} style={styles.modalClose}>
-                <X size={24} color={palette.textMuted}  />
+                <X size={24} color={theme.colors.textMuted} />
               </TouchableOpacity>
             </View>
 
@@ -268,7 +268,7 @@ export default function PlannerScreen() {
               <TextInput
                 style={styles.input}
                 placeholder="What needs to be done?"
-                placeholderTextColor={palette.textMuted}
+                placeholderTextColor={theme.colors.textMuted}
                 value={newTitle}
                 onChangeText={setNewTitle}
               />
@@ -279,7 +279,7 @@ export default function PlannerScreen() {
                   <TextInput
                     style={styles.input}
                     placeholder="e.g., 14:00"
-                    placeholderTextColor={palette.textMuted}
+                    placeholderTextColor={theme.colors.textMuted}
                     value={newTime}
                     onChangeText={setNewTime}
                   />
@@ -293,10 +293,10 @@ export default function PlannerScreen() {
                         onPress={() => setNewPriority(p)}
                         style={[
                           styles.priorityOption, 
-                          newPriority === p && { borderColor: palette.accentPrimary, backgroundColor: 'rgba(0, 212, 255, 0.1)' }
+                          newPriority === p && { borderColor: theme.colors.accentPrimary, backgroundColor: 'rgba(0, 212, 255, 0.1)' }
                         ]}
                       >
-                        <Text style={[styles.priorityText, newPriority === p && { color: palette.accentPrimary }]}>
+                        <Text style={[styles.priorityText, newPriority === p && { color: theme.colors.accentPrimary }]}>
                           {p.charAt(0).toUpperCase()}
                         </Text>
                       </TouchableOpacity>
@@ -314,7 +314,7 @@ export default function PlannerScreen() {
                   colors={['rgba(0, 212, 255, 0.3)', 'rgba(0, 153, 204, 0.3)']}
                   style={styles.submitButtonGradient}
                 >
-                  <Calendar size={20} color={palette.accentPrimary} style={{ marginRight: 8 }}  />
+                  <Calendar size={20} color={theme.colors.accentPrimary} style={{ marginRight: 8 }} />
                   <Text style={styles.submitButtonText}>Add to Planner</Text>
                 </LinearGradient>
               </TouchableOpacity>
@@ -330,7 +330,7 @@ export default function PlannerScreen() {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: palette.bgPrimary,
+    backgroundColor: theme.colors.bgPrimary,
   },
   scrollContainer: {
     padding: spacing.md,
@@ -348,25 +348,26 @@ const styles = StyleSheet.create({
     borderRadius: 24,
   },
   statValue: {
-    fontSize: 28,
-    fontWeight: '900',
+    fontSize: theme.typography.heading2,
+    fontWeight: '700',
+    fontFamily: theme.fonts.heading,
     marginBottom: 4,
   },
   statLabel: {
-    fontSize: 11,
-    color: palette.textSecondary,
+    fontSize: theme.typography.caption,
+    color: theme.colors.textSecondary,
     fontWeight: '700',
     textTransform: 'uppercase',
     letterSpacing: 1,
   },
   tabBar: {
     flexDirection: 'row',
-    backgroundColor: 'rgba(26, 26, 26, 0.8)',
-    borderRadius: 16,
+    backgroundColor: theme.colors.bgCard,
+    borderRadius: theme.radii.md,
     padding: 6,
     marginBottom: 24,
     borderWidth: 1,
-    borderColor: 'rgba(0, 255, 255, 0.1)',
+    borderColor: theme.colors.borderColor,
   },
   tab: {
     flex: 1,
@@ -382,11 +383,11 @@ const styles = StyleSheet.create({
   tabText: {
     fontSize: 13,
     fontWeight: '700',
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     letterSpacing: 0.5,
   },
   tabTextActive: {
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
     fontWeight: '900',
   },
   addButton: {
@@ -405,7 +406,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 255, 255, 0.05)',
   },
   addButtonText: {
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
     fontWeight: '900',
     fontSize: 16,
     letterSpacing: 0.5,
@@ -423,8 +424,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 255, 255, 0.4)',
   },
   sectionTitle: {
-    color: palette.textSecondary,
-    fontSize: 11,
+    color: theme.colors.textSecondary,
+    fontSize: theme.typography.caption,
     fontWeight: '900',
     textTransform: 'uppercase',
     letterSpacing: 2,
@@ -452,17 +453,18 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 255, 255, 0.05)',
   },
   checkboxDone: {
-    backgroundColor: palette.accentPrimary,
-    borderColor: palette.accentPrimary,
+    backgroundColor: theme.colors.accentPrimary,
+    borderColor: theme.colors.accentPrimary,
   },
   taskTitle: {
-    fontSize: 16,
-    fontWeight: '800',
-    color: '#FFF',
+    fontSize: theme.typography.body,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
     letterSpacing: 0.3,
   },
   taskTitleDone: {
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     textDecorationLine: 'line-through',
   },
   taskMeta: {
@@ -484,7 +486,7 @@ const styles = StyleSheet.create({
   },
   timeText: {
     fontSize: 12,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontWeight: '700',
   },
   scheduleCard: {
@@ -507,9 +509,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   scheduleTitle: {
-    fontSize: 17,
-    fontWeight: '900',
-    color: '#FFF',
+    fontSize: theme.typography.heading3,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
   },
   scheduleMeta: {
     flexDirection: 'row',
@@ -519,7 +522,7 @@ const styles = StyleSheet.create({
   },
   scheduleTime: {
     fontSize: 13,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontWeight: '600',
   },
   scheduleDot: {
@@ -527,7 +530,7 @@ const styles = StyleSheet.create({
   },
   scheduleDuration: {
     fontSize: 13,
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontWeight: '600',
   },
   emptyContainer: {
@@ -535,7 +538,7 @@ const styles = StyleSheet.create({
     paddingVertical: 60,
   },
   emptyText: {
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     fontSize: 15,
     fontWeight: '600',
   },
@@ -547,7 +550,7 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
   },
   modalContent: {
-    backgroundColor: '#0A0A0A',
+    backgroundColor: theme.colors.bgPrimary,
     borderTopLeftRadius: 32,
     borderTopRightRadius: 32,
     borderTopWidth: 1,
@@ -567,9 +570,10 @@ const styles = StyleSheet.create({
     marginBottom: 32,
   },
   modalTitle: {
-    fontSize: 22,
-    fontWeight: '900',
-    color: '#FFF',
+    fontSize: theme.typography.heading2,
+    fontWeight: '700',
+    color: theme.colors.textPrimary,
+    fontFamily: theme.fonts.heading,
     letterSpacing: 0.5,
   },
   modalClose: {
@@ -583,9 +587,9 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(255, 255, 255, 0.1)',
   },
   inputLabel: {
-    fontSize: 11,
+    fontSize: theme.typography.caption,
     fontWeight: '900',
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
     textTransform: 'uppercase',
     letterSpacing: 1.5,
     marginBottom: 10,
@@ -593,10 +597,10 @@ const styles = StyleSheet.create({
   },
   input: {
     backgroundColor: 'rgba(255, 255, 255, 0.03)',
-    borderRadius: 16,
+    borderRadius: theme.radii.md,
     paddingHorizontal: 18,
     paddingVertical: 16,
-    color: '#FFF',
+    color: theme.colors.textPrimary,
     fontSize: 16,
     borderWidth: 1,
     borderColor: 'rgba(255, 255, 255, 0.08)',
@@ -619,7 +623,7 @@ const styles = StyleSheet.create({
   priorityText: {
     fontSize: 14,
     fontWeight: '900',
-    color: palette.textSecondary,
+    color: theme.colors.textSecondary,
   },
   submitButton: {
     borderRadius: 20,
@@ -636,10 +640,9 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 255, 255, 0.1)',
   },
   submitButtonText: {
-    color: palette.accentPrimary,
+    color: theme.colors.accentPrimary,
     fontWeight: '900',
     fontSize: 17,
     letterSpacing: 0.5,
   },
 });
-

--- a/mobile/src/theme.ts
+++ b/mobile/src/theme.ts
@@ -1,17 +1,15 @@
 export const palette = {
-  bgPrimary: '#0A0A0A',      // Pure Deep Black
-  bgSecondary: '#1A1A1A',    // Deep Slate
-  bgCard: '#13131C',         // Figma AI Card Color
-  
-  accentPrimary: '#00FFFF',  // Super Cyan Pure
-  accentSecondary: '#A855F7', // Vibrant Purple
-  
-  textPrimary: '#FFFFFF',    // Pure White
-  textSecondary: '#BBC9CD',  // Muted Blue-Grey
-  textMuted: '#71717A',      // Figma Zinc-500
-  
-  borderColor: 'rgba(0, 255, 255, 0.2)', // Cyan Border
-  shadowColor: 'rgba(0, 255, 255, 0.3)', // Cyan Glow
+  bgPrimary: '#010106',
+  bgSecondary: '#0e0f1b',
+  bgCard: '#05060f',
+  overlay: 'rgba(1, 1, 4, 0.85)',
+  accentPrimary: '#00FFFF',
+  accentSecondary: '#A855F7',
+  textPrimary: '#F8FAFC',
+  textSecondary: '#BBC9CD',
+  textMuted: '#94A3B8',
+  borderColor: 'rgba(0, 255, 255, 0.2)',
+  glow: 'rgba(0, 255, 255, 0.3)',
 };
 
 export const spacing = {
@@ -22,7 +20,25 @@ export const spacing = {
   xl: 32,
 };
 
+export const typography = {
+  body: 16,
+  heading1: 26,
+  heading2: 22,
+  heading3: 18,
+  caption: 12,
+};
+
 export const theme = {
   colors: palette,
-  spacing: spacing,
+  spacing,
+  typography,
+  fonts: {
+    body: 'System',
+    heading: 'System',
+  },
+  radii: {
+    sm: 12,
+    md: 16,
+    lg: 20,
+  },
 };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,7 +52,7 @@ const App = (): JSX.Element => {
             <Route path="money" element={<MoneyView />} />
             <Route path="email" element={<EmailView />} />
             <Route path="calendar" element={<CalendarView />} />
-            <Route path="planner" element={<Navigate to="/" replace />} />
+            <Route path="planner" element={<Navigate to="/calendar" replace />} />
             
             <Route path="todolist" element={<Navigate to="/tasks" replace />} />
             <Route path="internet-speed" element={<InternetSpeedView />} />

--- a/web/src/components/cyan/CalendarView.tsx
+++ b/web/src/components/cyan/CalendarView.tsx
@@ -1,96 +1,302 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useOutletContext } from "react-router";
-import { Menu, Calendar, Clock, MapPin } from "lucide-react";
+import { Menu, Calendar as CalendarIcon, Clock } from "lucide-react";
+import { Calendar as DayPickerCalendar } from "../ui/calendar";
 import { GlassCard } from "./GlassCard";
 import { BurgerMenu } from "./BurgerMenu";
 import { Sidebar } from "./Sidebar";
+import { getAuthHeaders } from "../../services/auth";
+import { Task } from "../../types/tasks";
 
-const events = [
-  { id: 1, title: "Team Standup", time: "9:00 AM", duration: "30 min", location: "Virtual", color: "cyan" },
-  { id: 2, title: "Product Review", time: "11:00 AM", duration: "1 hour", location: "Conference A", color: "purple" },
-  { id: 3, title: "Lunch with Client", time: "1:00 PM", duration: "1 hour", location: "Downtown", color: "green" },
-  { id: 4, title: "Sprint Planning", time: "3:00 PM", duration: "2 hours", location: "Virtual", color: "cyan" },
-];
+const BACKEND_URL = import.meta.env.VITE_CLOUD_GATEWAY_URL || "http://localhost:8000/api/v1";
+
+const urgencyColors: Record<Task["urgency"], string> = {
+  high: "#F87171",
+  medium: "#FACC15",
+  low: "#A855F7",
+};
+
+const formatISODate = (date: Date) => date.toISOString().split("T")[0];
+
+const formatClock = (time: string | null) => {
+  if (!time) return "Any time";
+  const [hr, mn] = time.split(":");
+  if (hr === undefined || mn === undefined) return time;
+  const clone = new Date();
+  clone.setHours(Number(hr), Number(mn));
+  return clone.toLocaleTimeString("en-GB", { hour: "numeric", minute: "2-digit" });
+};
+
+const formatDuration = (duration: number | null) => {
+  if (!duration || Number.isNaN(duration)) return "Flexible";
+  if (duration >= 60) {
+    const hours = Math.floor(duration / 60);
+    const minutes = duration % 60;
+    return `${hours}h ${minutes}m`;
+  }
+  return `${duration} min`;
+};
 
 export function CalendarView() {
   const { isMobile } = useOutletContext<{ isMobile: boolean }>();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(() => new Date());
+  const [agenda, setAgenda] = useState<Task[]>([]);
+  const [agendaCache, setAgendaCache] = useState<Record<string, Task[]>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const cacheRef = useRef<Record<string, Task[]>>(agendaCache);
+
+  useEffect(() => {
+    cacheRef.current = agendaCache;
+  }, [agendaCache]);
+
+  useEffect(() => {
+    const iso = formatISODate(selectedDate);
+    const cached = cacheRef.current[iso];
+    if (cached) {
+      setAgenda(cached);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let canceled = false;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const headers = await getAuthHeaders();
+        const response = await fetch(`${BACKEND_URL}/tasks?date=${iso}`, { headers });
+        if (!response.ok) {
+          throw new Error(`Unable to load agenda (${response.status})`);
+        }
+        const payload: { tasks: Task[] } = await response.json();
+        if (canceled) return;
+        const items = payload.tasks ?? [];
+        setAgenda(items);
+        setAgendaCache((previous) => ({ ...previous, [iso]: items }));
+      } catch (err) {
+        if (canceled) return;
+        setError(err instanceof Error ? err.message : "Unable to load agenda");
+      } finally {
+        if (!canceled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      canceled = true;
+    };
+  }, [selectedDate]);
+
+  const stats = useMemo(() => {
+    const total = agenda.length;
+    const completed = agenda.filter((task) => task.status === "completed").length;
+    const pending = agenda.filter((task) => task.status === "pending").length;
+    const urgencies = agenda.reduce(
+      (acc, task) => {
+        acc[task.urgency] += 1;
+        return acc;
+      },
+      { high: 0, medium: 0, low: 0 },
+    );
+    return { total, completed, pending, urgencies };
+  }, [agenda]);
+
+  const summaryTiles = useMemo(
+    () => [
+      { label: "Scheduled", value: stats.total, accent: "#00FFFF" },
+      { label: "Completed", value: stats.completed, accent: "#22C55E" },
+      { label: "Pending", value: stats.pending, accent: "#FACC15" },
+      { label: "Urgent", value: stats.urgencies.high, accent: "#F87171" },
+    ],
+    [stats],
+  );
+
+  const cachedDates = useMemo(() => new Set(Object.keys(agendaCache)), [agendaCache]);
+  const calendarModifiers = useMemo(
+    () => ({
+      hasAgenda: (date: Date) => cachedDates.has(formatISODate(date)),
+    }),
+    [cachedDates],
+  );
+
+  const headerDate = selectedDate.toLocaleDateString("en-GB", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const isToday = selectedDate.toDateString() === new Date().toDateString();
+  const progressBase = Math.max(stats.total, 1);
+  const dayNumber = selectedDate.getDate().toString().padStart(2, "0");
+  const monthLabel = selectedDate.toLocaleDateString("en-GB", { month: "short" });
 
   return (
-    <div className={`${isMobile ? 'pt-16 pb-8' : 'pl-64'} min-h-screen`}>
+    <div className={`${isMobile ? "pt-16 pb-8" : "pl-64"} min-h-screen bg-[#03030b]`}>
       {!isMobile && <Sidebar />}
       <BurgerMenu isOpen={menuOpen} onClose={() => setMenuOpen(false)} />
 
-      <div className={`${isMobile ? 'p-4' : 'p-8'}`}>
-        <header className="mb-8">
-          <div className="flex items-center justify-between mb-6">
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-2">
-                <div className="h-1 w-12 bg-gradient-to-r from-[#00FFFF] to-transparent rounded-full"></div>
-                <span className="text-xs font-semibold text-[#BBC9CD] uppercase tracking-widest">
-                  Calendar
-                </span>
-              </div>
-              <h1 className="text-3xl md:text-4xl font-bold text-[#DAE2FD] tracking-tight">
-                Today's Schedule
-              </h1>
-              <p className="text-[#BBC9CD] mt-1">Friday, March 20, 2026</p>
+      <div className={`${isMobile ? "space-y-5 p-4" : "space-y-6 p-8"}`}>
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.5em] text-[#BBC9CD]">
+              <div className="h-1 w-12 rounded-full bg-gradient-to-r from-[#00FFFF] to-transparent" />
+              <span>Calendar</span>
             </div>
-
-            {isMobile && (
-              <button
-                onClick={() => setMenuOpen(true)}
-                className="p-3 rounded-xl bg-[#1A1A1A]/50 hover:bg-[#1A1A1A] text-[#BBC9CD] hover:text-[#00FFFF] transition-colors border border-[#00FFFF]/20"
-              >
-                <Menu className="w-6 h-6" />
-              </button>
-            )}
+            <h1 className="mt-3 text-3xl font-bold text-[#DAE2FD] md:text-4xl">Daily Rhythm</h1>
+            <p className="mt-2 max-w-2xl text-sm text-[#8D99A4]">
+              Choose a day, scan what matters first, and keep the agenda readable without the old planner dead-end.
+            </p>
           </div>
+
+          {isMobile && (
+            <button
+              onClick={() => setMenuOpen(true)}
+              className="flex h-12 w-12 items-center justify-center rounded-xl border border-[#00FFFF]/20 bg-[#111214] text-[#BBC9CD] hover:border-[#00FFFF]/40 hover:text-[#00FFFF]"
+            >
+              <Menu className="h-6 w-6" />
+            </button>
+          )}
         </header>
 
-        <div className="grid grid-cols-2 gap-4 mb-8">
-          <GlassCard className="!p-4">
-            <div className="p-2 rounded-lg bg-[#00FFFF]/10 inline-flex mb-3">
-              <Calendar className="w-5 h-5 text-[#00FFFF]" />
+        <div className={`${isMobile ? "space-y-5" : "grid grid-cols-[minmax(320px,420px)_minmax(0,1fr)] gap-6 items-start"}`}>
+          <GlassCard className="overflow-hidden !rounded-[28px] !border-[#00FFFF]/15 !bg-[#06070b]/95 !p-5">
+            <div className="mb-5 flex items-start justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.4em] text-[#BBC9CD]">
+                  <CalendarIcon className="h-4 w-4 text-[#00FFFF]" />
+                  <span>Month View</span>
+                </div>
+                <p className="mt-2 text-sm text-[#8D99A4]">Select a date to load tasks and keep your week in view.</p>
+              </div>
+              <div className="rounded-2xl border border-[#00FFFF]/15 bg-[#0a0d12] px-3 py-2 text-right">
+                <div className="text-[10px] uppercase tracking-[0.3em] text-[#6E7A86]">{monthLabel}</div>
+                <div className="text-2xl font-semibold text-[#DAE2FD]">{dayNumber}</div>
+              </div>
             </div>
-            <div className="text-2xl font-bold text-[#00FFFF] mb-1">4</div>
-            <div className="text-sm text-[#BBC9CD]">Events Today</div>
+            <DayPickerCalendar
+              mode="single"
+              selected={selectedDate}
+              onSelect={(day) => day && setSelectedDate(day)}
+              weekStartsOn={1}
+              className="w-full"
+              modifiers={calendarModifiers}
+              modifiersClassNames={{
+                hasAgenda:
+                  "after:absolute after:bottom-2 after:left-1/2 after:h-1.5 after:w-1.5 after:-translate-x-1/2 after:rounded-full after:bg-[#00FFFF] after:shadow-[0_0_10px_rgba(0,255,255,0.75)]",
+              }}
+            />
+            <div className="mt-5 flex flex-wrap gap-2">
+              <span className="rounded-full border border-[#00FFFF]/20 bg-[#00FFFF]/10 px-3 py-1 text-[11px] font-medium text-[#BFFBFF]">
+                Cyan dot = cached agenda
+              </span>
+              <span className="rounded-full border border-[#A855F7]/20 bg-[#A855F7]/10 px-3 py-1 text-[11px] font-medium text-[#E7D4FF]">
+                Purple = today
+              </span>
+            </div>
+            {error && <p className="mt-4 text-xs text-[#F87171]">{error}</p>}
           </GlassCard>
 
-          <GlassCard className="!p-4">
-            <div className="p-2 rounded-lg bg-[#00FFFF]/10 inline-flex mb-3">
-              <Clock className="w-5 h-5 text-[#00FFFF]" />
-            </div>
-            <div className="text-2xl font-bold text-[#00FFFF] mb-1">4.5h</div>
-            <div className="text-sm text-[#BBC9CD]">Total Time</div>
-          </GlassCard>
-        </div>
-
-        <div className="space-y-3">
-          {events.map((event) => (
-            <GlassCard key={event.id} className="!p-4 hover:border-[#00FFFF]/40 transition-all cursor-pointer">
-              <div className="flex items-start gap-4">
-                <div className={`h-full w-1 rounded-full flex-shrink-0 ${
-                  event.color === 'cyan' ? 'bg-[#00FFFF]' :
-                  event.color === 'purple' ? 'bg-purple-400' :
-                  'bg-green-400'
-                }`}></div>
-                <div className="flex-1">
-                  <h3 className="font-bold text-[#DAE2FD] mb-2">{event.title}</h3>
-                  <div className="flex flex-col gap-1 text-sm text-[#BBC9CD]">
-                    <div className="flex items-center gap-2">
-                      <Clock className="w-4 h-4" />
-                      <span>{event.time} • {event.duration}</span>
+          <div className="space-y-5">
+            <GlassCard className="!rounded-[28px] !border-[#00FFFF]/15 !bg-[#06070b]/95 !p-6">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <p className="text-[11px] uppercase tracking-[0.38em] text-[#6E7A86]">Selected day</p>
+                  <h2 className="mt-2 text-2xl font-semibold text-[#DAE2FD] md:text-3xl">{headerDate}</h2>
+                  <p className="mt-2 text-sm text-[#8D99A4]">
+                    {isToday
+                      ? "Today is live. Counts update from the current task list."
+                      : "This date is loaded from the same task API and cached locally for faster revisits."}
+                  </p>
+                </div>
+                <span className="inline-flex w-fit rounded-full border border-[#00FFFF]/20 bg-[#00FFFF]/8 px-3 py-1 text-[11px] uppercase tracking-[0.35em] text-[#BFFBFF]">
+                  {isToday ? "Today" : "Selected"}
+                </span>
+              </div>
+              <div className="mt-6 grid grid-cols-2 gap-3 xl:grid-cols-4">
+                {summaryTiles.map((tile) => (
+                  <div key={tile.label} className="rounded-2xl border border-white/6 bg-[#0b0e14] p-4">
+                    <div className="flex items-center justify-between">
+                      <p className="text-[10px] uppercase tracking-[0.3em] text-[#6E7A86]">{tile.label}</p>
+                      <span className="h-3 w-3 rounded-full" style={{ background: tile.accent }} />
                     </div>
-                    <div className="flex items-center gap-2">
-                      <MapPin className="w-4 h-4" />
-                      <span>{event.location}</span>
+                    <p className="mt-4 text-3xl font-semibold text-[#F3F7FF]">{tile.value}</p>
+                    <div className="mt-2 h-1 w-full rounded-full bg-[#111214]">
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          width: `${Math.min((tile.value / progressBase) * 100, 100)}%`,
+                          background: tile.accent,
+                          transition: "width 0.25s ease",
+                        }}
+                      />
                     </div>
                   </div>
-                </div>
+                ))}
               </div>
             </GlassCard>
-          ))}
+
+            <GlassCard className="!rounded-[28px] !border-[#00FFFF]/15 !bg-[#06070b]/95 !p-6">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-[11px] uppercase tracking-[0.38em] text-[#6E7A86]">Daily agenda</p>
+                  <h3 className="mt-2 text-xl font-semibold text-[#DAE2FD] md:text-2xl">{headerDate}</h3>
+                </div>
+                <span className="text-[11px] uppercase tracking-[0.45em] text-[#00FFFF]">Live</span>
+              </div>
+              <div className="mt-5 space-y-3">
+                {loading ? (
+                  <p className="text-sm text-[#BBC9CD]">Loading tasks…</p>
+                ) : agenda.length === 0 ? (
+                  <div className="rounded-2xl border border-dashed border-[#00FFFF]/15 bg-[#090b10] p-5 text-sm text-[#8D99A4]">
+                    No items yet. Add tasks from the planner to fill the day.
+                  </div>
+                ) : (
+                  agenda.map((task) => (
+                    <div
+                      key={task.id}
+                      className="group relative overflow-hidden rounded-[22px] border border-white/6 bg-[#0b0e14] p-4 transition hover:border-[#00FFFF]/30"
+                    >
+                      <div
+                        className="absolute inset-y-0 left-0 w-1 rounded-full"
+                        style={{ background: urgencyColors[task.urgency] }}
+                      />
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="pl-2">
+                          <p className="text-lg font-semibold text-[#DAE2FD]">{task.title}</p>
+                          {task.description && <p className="mt-1 text-sm text-[#8D99A4]">{task.description}</p>}
+                        </div>
+                        <div className="rounded-2xl border border-[#00FFFF]/10 bg-[#06080d] px-3 py-2 text-right text-xs uppercase tracking-[0.3em] text-[#BBC9CD]">
+                          <span className="flex items-center justify-end gap-2 text-[11px] text-[#00FFFF]">
+                            <Clock className="h-4 w-4" />
+                            {formatClock(task.time)}
+                          </span>
+                          <span className="mt-1 block text-[10px] text-[#71717A]">{formatDuration(task.duration)}</span>
+                        </div>
+                      </div>
+                      <div className="mt-4 flex flex-wrap items-center justify-between gap-3 pl-2 text-[11px] uppercase tracking-[0.3em]">
+                        <span className={`flex items-center gap-1 font-medium ${task.status === "completed" ? "text-[#22C55E]" : "text-[#FACC15]"}`}>
+                          {task.status === "completed" ? "Completed" : "Pending"}
+                        </span>
+                        <span
+                          className="rounded-full border border-white/10 px-2.5 py-1 font-semibold"
+                          style={{
+                            color: urgencyColors[task.urgency],
+                            borderColor: `${urgencyColors[task.urgency]}33`,
+                            background: `${urgencyColors[task.urgency]}1f`,
+                          }}
+                        >
+                          {task.urgency}
+                        </span>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </GlassCard>
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/components/cyan/JobsView.tsx
+++ b/web/src/components/cyan/JobsView.tsx
@@ -32,7 +32,6 @@ const SOURCE_META: Record<string, { label: string; color: string; bg: string; bo
   "adzuna":          { label: "Adzuna",             color: "#f97316",  bg: "rgba(249,115,22,0.12)",  border: "rgba(249,115,22,0.3)" },
   "jobicy":          { label: "Jobicy",             color: "#818cf8",  bg: "rgba(129,140,248,0.12)", border: "rgba(129,140,248,0.3)" },
   "himalayas":       { label: "Himalayas",          color: "#2dd4bf",  bg: "rgba(45,212,191,0.12)",  border: "rgba(45,212,191,0.3)" },
-  "reed":            { label: "Reed",               color: "#f87171",  bg: "rgba(248,113,113,0.12)", border: "rgba(248,113,113,0.3)" },
 };
 
 function getSourceMeta(source?: string | null) {

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -103,14 +103,14 @@ const Sidebar: React.FC = () => {
             </svg>
             {!collapsed && <span>Health</span>}
           </NavLink>
-          <NavLink to="/planner" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`} title="Planner">
+          <NavLink to="/calendar" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`} title="Calendar">
             <svg className="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
               <line x1="16" y1="2" x2="16" y2="6"></line>
               <line x1="8" y1="2" x2="8" y2="6"></line>
               <line x1="3" y1="10" x2="21" y2="10"></line>
             </svg>
-            {!collapsed && <span>Planner</span>}
+            {!collapsed && <span>Calendar</span>}
           </NavLink>
         </nav>
 

--- a/web/src/components/ui/calendar.tsx
+++ b/web/src/components/ui/calendar.tsx
@@ -16,44 +16,44 @@ function Calendar({
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
+      className={cn("p-0", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row gap-2",
+        months: "flex flex-col gap-4",
         month: "flex flex-col gap-4",
-        caption: "flex justify-center pt-1 relative items-center w-full",
-        caption_label: "text-sm font-medium",
-        nav: "flex items-center gap-1",
+        caption: "relative flex items-center justify-center border-b border-[#00FFFF]/10 pb-4",
+        caption_label: "text-sm font-semibold uppercase tracking-[0.32em] text-[#DAE2FD]",
+        nav: "flex items-center gap-2",
         nav_button: cn(
           buttonVariants({ variant: "outline" }),
-          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+          "flex h-9 w-9 items-center justify-center rounded-xl border border-[#00FFFF]/20 bg-[#08090d] p-0 text-[#BBC9CD] opacity-100 transition hover:border-[#00FFFF]/40 hover:bg-[#10131a] hover:text-[#00FFFF]",
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-x-1",
-        head_row: "flex",
+        nav_button_previous: "absolute left-0",
+        nav_button_next: "absolute right-0",
+        table: "w-full border-separate border-spacing-y-2",
+        head_row: "grid grid-cols-7 gap-2",
         head_cell:
-          "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
+          "text-center text-[11px] font-semibold uppercase tracking-[0.28em] text-[#6E7A86]",
+        row: "grid grid-cols-7 gap-2",
         cell: cn(
-          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md",
+          "relative text-center text-sm focus-within:relative focus-within:z-20",
           props.mode === "range"
             ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
-            : "[&:has([aria-selected])]:rounded-md",
+            : "",
         ),
         day: cn(
           buttonVariants({ variant: "ghost" }),
-          "size-8 p-0 font-normal aria-selected:opacity-100",
+          "h-12 w-full rounded-2xl border border-transparent bg-[#08090d] p-0 text-sm font-semibold text-[#DAE2FD] aria-selected:opacity-100 hover:border-[#00FFFF]/30 hover:bg-[#0d1117] hover:text-[#00FFFF] focus-visible:ring-[#00FFFF]/30",
         ),
         day_range_start:
           "day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground",
         day_range_end:
           "day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground",
         day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        day_today: "bg-accent text-accent-foreground",
+          "border border-[#00FFFF]/50 bg-[#00FFFF]/15 text-[#00FFFF] shadow-[0_0_18px_rgba(0,255,255,0.18)] hover:border-[#00FFFF]/60 hover:bg-[#00FFFF]/20 hover:text-[#00FFFF] focus:bg-[#00FFFF]/20 focus:text-[#00FFFF]",
+        day_today: "border border-[#A855F7]/35 bg-[#A855F7]/12 text-[#F4ECFF]",
         day_outside:
-          "day-outside text-muted-foreground aria-selected:text-muted-foreground",
-        day_disabled: "text-muted-foreground opacity-50",
+          "day-outside bg-transparent text-[#49525D] opacity-60 hover:bg-transparent hover:text-[#6E7A86]",
+        day_disabled: "text-[#49525D] opacity-40",
         day_range_middle:
           "aria-selected:bg-accent aria-selected:text-accent-foreground",
         day_hidden: "invisible",

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -1,81 +1,82 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --font-size: 16px;
-  --background: #ffffff;
-  --foreground: oklch(0.145 0 0);
-  --card: #ffffff;
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: #030213;
-  --primary-foreground: oklch(1 0 0);
-  --secondary: oklch(0.95 0.0058 264.53);
-  --secondary-foreground: #030213;
-  --muted: #ececf0;
-  --muted-foreground: #717182;
-  --accent: #e9ebef;
-  --accent-foreground: #030213;
-  --destructive: #d4183d;
-  --destructive-foreground: #ffffff;
-  --border: rgba(0, 0, 0, 0.1);
-  --input: transparent;
-  --input-background: #f3f3f5;
-  --switch-background: #cbced4;
-  --font-weight-medium: 500;
+  --font-family: "Inter", "Roboto", "Segoe UI", system-ui, sans-serif;
+  --font-size-base: 18px;
+  --background: #02030a;
+  --foreground: #eef2ff;
+  --card: #05070f;
+  --card-foreground: #f8fafc;
+  --popover: #080a12;
+  --popover-foreground: #e2e8f0;
+  --primary: #00ffff;
+  --primary-foreground: #03030b;
+  --secondary: #a855f7;
+  --secondary-foreground: #e2e8f0;
+  --muted: #11121b;
+  --muted-foreground: #94a3b8;
+  --accent: #00ffff;
+  --accent-foreground: #03030b;
+  --destructive: #e11d48;
+  --destructive-foreground: #f8fafc;
+  --border: rgba(0, 255, 255, 0.15);
+  --input: rgba(255, 255, 255, 0.04);
+  --input-background: #03030b;
+  --switch-background: #00ffff;
+  --font-weight-medium: 600;
   --font-weight-normal: 400;
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: #030213;
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --ring: rgba(0, 255, 255, 0.25);
+  --chart-1: #00ffff;
+  --chart-2: #a855f7;
+  --chart-3: #f97316;
+  --chart-4: #22c55e;
+  --chart-5: #fb7185;
+  --radius: 0.75rem;
+  --sidebar: #05070f;
+  --sidebar-foreground: #e2e8f0;
+  --sidebar-primary: #0f172a;
+  --sidebar-primary-foreground: #bedeff;
+  --sidebar-accent: #00ffff;
+  --sidebar-accent-foreground: #03030b;
+  --sidebar-border: rgba(255, 255, 255, 0.06);
+  --sidebar-ring: rgba(0, 255, 255, 0.25);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.145 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.145 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
-  --font-weight-medium: 500;
+  --background: #010106;
+  --foreground: #f8fafc;
+  --card: #02030a;
+  --card-foreground: #f1f5f9;
+  --popover: #03030b;
+  --popover-foreground: #e2e8f0;
+  --primary: #00ffff;
+  --primary-foreground: #03030b;
+  --secondary: #a855f7;
+  --secondary-foreground: #e2e8f0;
+  --muted: #0a0b14;
+  --muted-foreground: #94a3b8;
+  --accent: #00ffff;
+  --accent-foreground: #03030b;
+  --destructive: #ef4444;
+  --destructive-foreground: #f8fafc;
+  --border: rgba(255, 255, 255, 0.08);
+  --input: rgba(255, 255, 255, 0.05);
+  --ring: rgba(0, 255, 255, 0.35);
+  --font-weight-medium: 600;
   --font-weight-normal: 400;
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.269 0 0);
-  --sidebar-ring: oklch(0.439 0 0);
+  --chart-1: #00ffff;
+  --chart-2: #7c3aed;
+  --chart-3: #fb923c;
+  --chart-4: #22c55e;
+  --chart-5: #f472b6;
+  --sidebar: #010106;
+  --sidebar-foreground: #f1f5f9;
+  --sidebar-primary: #020617;
+  --sidebar-primary-foreground: #bedeff;
+  --sidebar-accent: #00ffff;
+  --sidebar-accent-foreground: #03030b;
+  --sidebar-border: rgba(255, 255, 255, 0.05);
+  --sidebar-ring: rgba(0, 255, 255, 0.25);
 }
 
 @theme inline {
@@ -126,6 +127,9 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-family);
+    font-size: var(--font-size-base);
+    line-height: 1.6;
   }
 
   /**
@@ -134,47 +138,38 @@
   */
 
   html {
-    font-size: var(--font-size);
+    font-size: var(--font-size-base);
   }
 
   h1 {
-    font-size: var(--text-2xl);
+    font-size: 2.75rem;
     font-weight: var(--font-weight-medium);
-    line-height: 1.5;
+    line-height: 1.3;
   }
 
   h2 {
-    font-size: var(--text-xl);
+    font-size: 2.25rem;
     font-weight: var(--font-weight-medium);
-    line-height: 1.5;
+    line-height: 1.35;
   }
 
   h3 {
-    font-size: var(--text-lg);
+    font-size: 1.9rem;
     font-weight: var(--font-weight-medium);
-    line-height: 1.5;
+    line-height: 1.4;
   }
 
   h4 {
-    font-size: var(--text-base);
+    font-size: 1.5rem;
     font-weight: var(--font-weight-medium);
-    line-height: 1.5;
+    line-height: 1.45;
   }
 
-  label {
-    font-size: var(--text-base);
-    font-weight: var(--font-weight-medium);
-    line-height: 1.5;
-  }
-
-  button {
-    font-size: var(--text-base);
-    font-weight: var(--font-weight-medium);
-    line-height: 1.5;
-  }
-
+  label,
+  button,
   input {
-    font-size: var(--text-base);
+    font-family: var(--font-family);
+    font-size: 1rem;
     font-weight: var(--font-weight-normal);
     line-height: 1.5;
   }


### PR DESCRIPTION
## Summary
- Add full-screen interactive `CalendarView` component wired at `/calendar` route; `/planner` redirects here
- Add `web/src/components/ui/calendar.tsx` base calendar UI primitive
- Update OLED dark theme CSS variables in `theme.css` (deep blacks `#000000`, slate/deep blue accents)
- Update `Sidebar.tsx` and `JobsView.tsx` for layout alignment (#122 dashboard scaling)
- Update all mobile screens (Chat, Dashboard, Feeds, Health, Planner) for consistent text scaling
- Update `MobileCard`, `MobileHeader`, `MobileMenu`, `Themed.tsx`, `theme.ts` for OLED palette

## Issues closed
Closes #121
Closes #122

## Test plan
- [ ] CalendarView renders at `/calendar` route
- [ ] Planner tab redirects to `/calendar`
- [ ] Calendar fetches tasks from `/api/v1/tasks` and renders date-click agenda view
- [ ] OLED dark theme applied correctly (deep blacks, slate accents visible)
- [ ] Hover/active interactive states visible on OLED displays
- [ ] Dashboard text scaling consistent across web and mobile
- [ ] No regressions on Feeds, Email, Chat, Health tabs
- [ ] `npm run lint` passes